### PR TITLE
test(ask): cover stopwords, multi-keyword, ties, order, and archived

### DIFF
--- a/src/server/services/ask/resolver.test.ts
+++ b/src/server/services/ask/resolver.test.ts
@@ -81,4 +81,115 @@ describe("Ask resolver", () => {
 		const hits = await fetchSessionsById(["a", "c"]);
 		expect(hits.map((h) => h.sessionId).sort()).toEqual(["a", "c"]);
 	});
+
+	test("stopword-only tokens are dropped before scoring", async () => {
+		await insertSession({ id: "api", displayName: "api-gateway", cwd: "/srv/api" });
+		await insertSession({ id: "other", displayName: "unrelated-name", cwd: "/srv/other" });
+
+		// "is the api session healthy?" — stopwords "is", "the", "session" are
+		// in STOPWORDS; "api" and "healthy" survive tokenization. The API
+		// session should match via "api"; the other session matches nothing.
+		const hits = await resolveCandidateSessions({
+			message: "is the api session healthy?",
+		});
+		const ids = hits.map((h) => h.sessionId);
+		expect(ids).toContain("api");
+		expect(ids).not.toContain("other");
+	});
+
+	test("multi-keyword hits in cwd outrank single-keyword hits", async () => {
+		await insertSession({
+			id: "both",
+			displayName: "alpha",
+			cwd: "/repos/sourcebridge/oauth-provider",
+		});
+		await insertSession({
+			id: "one",
+			displayName: "beta",
+			cwd: "/repos/sourcebridge/ui",
+		});
+
+		const hits = await resolveCandidateSessions({
+			message: "the sourcebridge oauth session",
+		});
+		expect(hits[0].sessionId).toBe("both");
+		expect(hits.map((h) => h.sessionId)).toContain("one");
+	});
+
+	test("ties break by lastActivityAt descending", async () => {
+		// Two sessions that score identically on "target": the newer one
+		// must come first. We set lastActivityAt manually to avoid racing
+		// on the default datetime('now') clock tick.
+		const older = "2020-01-01T00:00:00.000Z";
+		const newer = "2030-01-01T00:00:00.000Z";
+		await db
+			.insert(sessions)
+			.values({
+				sessionId: "old-tie",
+				agentType: "claude_code",
+				displayName: "target",
+				status: "active",
+				cwd: "/tmp",
+				isWorking: false,
+				lastActivityAt: older,
+				startedAt: older,
+			})
+			.execute();
+		await db
+			.insert(sessions)
+			.values({
+				sessionId: "new-tie",
+				agentType: "claude_code",
+				displayName: "target",
+				status: "active",
+				cwd: "/tmp",
+				isWorking: false,
+				lastActivityAt: newer,
+				startedAt: newer,
+			})
+			.execute();
+
+		const hits = await resolveCandidateSessions({ message: "target" });
+		// Both matched identically (same scoring inputs); newer one should win the tie.
+		expect(hits[0].sessionId).toBe("new-tie");
+		expect(hits[1].sessionId).toBe("old-tie");
+		expect(hits[0].score).toBe(hits[1].score);
+	});
+
+	test("fetchSessionsById preserves input order", async () => {
+		await insertSession({ id: "a", displayName: "one" });
+		await insertSession({ id: "b", displayName: "two" });
+		await insertSession({ id: "c", displayName: "three" });
+
+		// Passing ["b", "a"] must return in that order, not alphabetic / insertion order.
+		const hits = await fetchSessionsById(["b", "a"]);
+		expect(hits.map((h) => h.sessionId)).toEqual(["b", "a"]);
+	});
+
+	test("archived sessions are excluded from the resolver pool", async () => {
+		// Status not in { active, idle } and not isWorking=true must NOT
+		// leak into matches. We insert with a status ("archived") the schema
+		// accepts (text column, no CHECK constraint) but the resolver's
+		// WHERE clause filters out.
+		await db
+			.insert(sessions)
+			.values({
+				sessionId: "archived-one",
+				agentType: "claude_code",
+				displayName: "archived-target",
+				// biome-ignore lint/suspicious/noExplicitAny: schema is permissive text
+				status: "archived" as any,
+				cwd: "/tmp",
+				isWorking: false,
+				lastActivityAt: new Date().toISOString(),
+				startedAt: new Date().toISOString(),
+			})
+			.execute();
+		await insertSession({ id: "active-one", displayName: "archived-target" });
+
+		const hits = await resolveCandidateSessions({ message: "archived-target" });
+		const ids = hits.map((h) => h.sessionId);
+		expect(ids).toContain("active-one");
+		expect(ids).not.toContain("archived-one");
+	});
 });

--- a/src/server/services/ask/resolver.ts
+++ b/src/server/services/ask/resolver.ts
@@ -170,14 +170,20 @@ export async function resolveCandidateSessions(input: ResolveInput): Promise<Res
 export async function fetchSessionsById(ids: string[]): Promise<ResolvedSession[]> {
 	if (ids.length === 0) return [];
 	const rows = await db.select().from(sessions).where(inArray(sessions.sessionId, ids));
-	return rows.map((row) => ({
-		sessionId: row.sessionId,
-		displayName: row.displayName,
-		cwd: row.cwd,
-		status: row.status,
-		isWorking: Boolean(row.isWorking),
-		agentType: row.agentType ?? "unknown",
-		lastActivityAt: row.lastActivityAt,
-		score: 100, // explicitly-picked rows always rank first
-	}));
+	// SQLite's IN clause doesn't preserve input order; re-order rows to match
+	// the caller's id list so "@mention"-style references in the UI stay stable.
+	const byId = new Map(rows.map((row) => [row.sessionId, row]));
+	return ids
+		.map((id) => byId.get(id))
+		.filter((row): row is (typeof rows)[number] => Boolean(row))
+		.map((row) => ({
+			sessionId: row.sessionId,
+			displayName: row.displayName,
+			cwd: row.cwd,
+			status: row.status,
+			isWorking: Boolean(row.isWorking),
+			agentType: row.agentType ?? "unknown",
+			lastActivityAt: row.lastActivityAt,
+			score: 100, // explicitly-picked rows always rank first
+		}));
 }


### PR DESCRIPTION
## Summary

Adds the five test cases requested in #10 (stopword filtering, multi-keyword ranking, tie-break ordering, explicit-id order preservation, archived-session exclusion) plus one small implementation fix that the `fetchSessionsById preserves input order` test surfaced.

Closes #10.

## Tests

All five tests use the shared `src/server/services/ai/__test_db.ts` helper, not a private sqlite instance (acceptance criterion 3).

1. **Stopword filtering** - "is the api session healthy?" ends up scoring against `api` and `healthy`; `is`, `the`, and `session` are in `STOPWORDS` at `resolver.ts:36-72`. A session named `api-gateway` matches via `api`; a session named `unrelated-name` matches nothing.

2. **Multi-keyword match** - "the sourcebridge oauth session" ranks a cwd `/repos/sourcebridge/oauth-provider` above `/repos/sourcebridge/ui` because `scoreSession` adds +2 per token-in-haystack hit (both tokens in the first, only one in the second).

3. **Stable ordering on ties** - two sessions that score identically on `target` sort by `lastActivityAt` descending. Uses explicit timestamps (2020 vs 2030) to avoid racing on the default `datetime('now')` tick.

4. **fetchSessionsById preserves input order** - passing `["b", "a"]` returns `["b", "a"]`, not the SQLite IN-clause default. See implementation fix below.

5. **Archived sessions excluded** - a session with `status: "archived"` (and `isWorking: false`) does not leak into the resolver pool. Inserts via `db.insert(...)` directly so the test exercises the resolver's WHERE clause without being restricted by the `insertSession` helper's narrower type union.

Test count before: 4. After: 9. `bun test src/server/services/ask/resolver.test.ts` runs all 9 green.

## Implementation fix

`fetchSessionsById` at `src/server/services/ask/resolver.ts:170` previously mapped the raw SQLite result:

```ts
const rows = await db.select().from(sessions).where(inArray(sessions.sessionId, ids));
return rows.map((row) => ({ ... }));
```

SQLite's `IN` clause doesn't preserve input order, so callers got back results in insertion / rowid order. The fix indexes the rows by `sessionId` and walks `ids` in the order the caller passed them:

```ts
const byId = new Map(rows.map((row) => [row.sessionId, row]));
return ids
  .map((id) => byId.get(id))
  .filter((row): row is (typeof rows)[number] => Boolean(row))
  .map((row) => ({ ... }));
```

This keeps "@mention"-style references in the UI stable regardless of how the sessions were inserted.

## Testing

```
bun test src/server/services/ask/resolver.test.ts
#  9 pass
#  0 fail
#  15 expect() calls

bunx biome check src/server/services/ask/resolver.ts src/server/services/ask/resolver.test.ts
# Checked 2 files in 2ms. No fixes applied.

bunx tsc --noEmit
# (exit 0)
```

## AI disclosure

This contribution was developed with AI assistance (Claude Code).
