### PR TITLE
fix(install): correct repo URL owner (jaystuart → jstuart0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/jaystuart/agentpulse"
+		"url": "https://github.com/jstuart0/agentpulse"
 	},
 	"keywords": ["ai", "agent", "monitoring", "dashboard", "claude-code", "codex", "developer-tools"],
 	"trustedDependencies": ["@biomejs/biome"]

--- a/scripts/install-local.ps1
+++ b/scripts/install-local.ps1
@@ -1,6 +1,6 @@
 param(
   [string]$Ref = "main",
-  [string]$Repo = "https://github.com/jaystuart/agentpulse.git",
+  [string]$Repo = "https://github.com/jstuart0/agentpulse.git",
   [string]$Dir = "$HOME\.agentpulse\app",
   [string]$DataDir = "$HOME\.agentpulse\data",
   [int]$Port = 3000,

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # AgentPulse local installer
 # One-command Bun + SQLite deployment for macOS/Linux.
 
-REPO_URL="https://github.com/jaystuart/agentpulse.git"
+REPO_URL="https://github.com/jstuart0/agentpulse.git"
 REPO_REF="main"
 INSTALL_DIR="${HOME}/.agentpulse/app"
 DATA_DIR="${HOME}/.agentpulse/data"


### PR DESCRIPTION
## Problem

Both installers and the package manifest point at a repository owner that doesn't exist:

- `scripts/install-local.sh` → `REPO_URL`
- `scripts/install-local.ps1` → `$Repo`
- `package.json` → `repository.url`

All three reference `github.com/jaystuart/agentpulse`, which returns **404**. The README's one-line install command therefore fails with `fatal: repository not found`.

## Fix

Point all three at the canonical `github.com/jstuart0/agentpulse` — the owner used everywhere else in the repo (README, CONTRIBUTING, CHANGELOG, CI badges).

## Notes

- No code changes; metadata/URL only.
- Both the Linux/macOS and Windows installers were affected.
- Related to #4.
