### PR TITLE
fix(install): serve frontend in prod + give services a PATH to bun

### DIFF
--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -124,7 +124,7 @@ echo "  Installing dependencies..."
 bun install
 
 echo "  Building application..."
-bun run build
+NODE_ENV=production bun run build
 
 ENV_FILE="${INSTALL_DIR}/.env.local"
 cat > "${ENV_FILE}" <<EOF
@@ -217,6 +217,8 @@ After=network.target
 Type=simple
 WorkingDirectory=${INSTALL_DIR}
 EnvironmentFile=${ENV_FILE}
+Environment=HOME=${HOME}
+Environment=PATH=${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 ExecStart=${HOME}/.bun/bin/bun run start
 Restart=always
 RestartSec=3
@@ -277,6 +279,8 @@ create_launchd() {
   <string>${INSTALL_DIR}</string>
   <key>EnvironmentVariables</key>
   <dict>
+    <key>HOME</key><string>${HOME}</string>
+    <key>PATH</key><string>${HOME}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     <key>PORT</key><string>${PORT}</string>
     <key>HOST</key><string>${HOST}</string>
     <key>PUBLIC_URL</key><string>${PUBLIC_URL}</string>


### PR DESCRIPTION
## Problem

A fresh install from `install-local.sh` came up non-functional in two independent ways, both visible right after the documented one-line install.

**1. Every page returns 404 (frontend never served).** The build ran `bun run build` without `NODE_ENV=production`. The bundler inlines `process.env.NODE_ENV` at build time, so `config.isProduction` was compiled to `false` and the static-file handler (`if (config.isProduction) { ... }`) was dropped from the bundle. `/api/v1/health` returned 200, but `/` and every route returned 404.

**2. The service crash-loops with `bun: command not found`.** The main service unit (`create_systemd` / `create_launchd`) had no `PATH`. `ExecStart` calls `bun` by absolute path, but `bun run start` then invokes a bare `bun`, which isn't on the minimal service `PATH`. The unit exits 127 and `Restart=always` loops forever — the installer hangs on "Waiting for AgentPulse to start...".

## Fix

- Build with `NODE_ENV=production` so `isProduction` is compiled in and the frontend is served.
- Add `HOME`/`PATH` to the systemd unit and the launchd plist — the same entries the supervisor units already use (`create_supervisor_systemd` / `create_supervisor_launchd`). Just brings the main service in line with them.

## Notes

- Independent of #15 (that fixes the clone URL); both are needed for a working install.
- Verified on Linux (WSL2 + systemd): after the fix the service stays up and `/` serves the dashboard.
