### PR TITLE
Fix Authentik SSO password-prompt (forwardauth→ap_session bridge) + watcher CPU soft-lockup [AGEN-5, AGEN-6]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ bun run test:watch       # Run tests in watch mode
     - `sessions.ts` — Session list, detail, notes, rename, archive, delete, claude-md
     - `settings.ts` — Settings allowlist-gated CRUD
     - `setup.ts` — Self-contained hook setup script endpoint
-    - `supervisors.ts` — Supervisor registry and host routing
+    - `supervisors.ts` — Supervisor registry and host routing; exports `supervisorsAgentRouter` (edge-public agent endpoints at `/api/v1/supervisors/*`) and `supervisorsAdminRouter` (management endpoints at `/api/v1/admin/supervisors/*`, forwardauth-gated)
     - `templates.ts` — Session template CRUD + distillation
   - `services/` - ~30 service files + subdirectories:
     - `ai/` — AI control plane (~50 files): classifier, watcher runner, HITL, proposals, context, dispatch-filter, redactor, secrets, risk-classes, spend, auto-watcher, inbox, digest, alert-rule evaluator, template distillation, launch recommender, and more
@@ -77,7 +77,7 @@ bun run test:watch       # Run tests in watch mode
     - `session-tracker.ts`, `settings-service.ts`, `supervisor-registry.ts`
     - `telemetry.ts`, `template-preview.ts`, `transcript-sync.ts`
   - `db/` - Drizzle client (`client.ts`), dialect-aware boot path, per-dialect migration runner; schema split across `db/schema/{core,ai,ask-projects}/` with per-dialect entry files (`schema/sqlite.ts`, `schema/postgres.ts`) and a runtime barrel (`schema/index.ts`); generated SQL baselines in `drizzle/sqlite/` and `drizzle/postgres/`
-  - `auth/` - API key generation/verification, Authentik middleware (header trust gate)
+  - `auth/` - API key generation/verification, forwardauth bridge (`forwardauth-bridge.ts`), header trust gate + session resolver (`middleware.ts`)
   - `ws/` - WebSocket handler with pub/sub
 - `src/web/` - React frontend
   - `pages/` - AskPage, DashboardPage, DigestPage, HostsPage, InboxPage, LaunchDetailPage, LoginPage, ProjectsPage, SearchPage, SessionDetailPage, SettingsPage, SetupPage, TemplatesPage
@@ -160,6 +160,9 @@ Do NOT use or document `503 / ai_kill_switch_active` — that code and message w
 - `DISABLE_AUTH=true` - No auth, all endpoints open (default for local use)
 - Auth enabled - API key for hooks, forwardauth SSO for dashboard (k8s deployment)
   - **Forwardauth trust secret**: `FORWARDAUTH_TRUST_SECRET` env var (required for SSO production deployments). AgentPulse works with any forwardauth-capable IdP — Authentik (default), Authelia, oauth2-proxy, Pomerium, Cloudflare Access. Traefik's `agentpulse-inject-verify` middleware injects the shared secret; AgentPulse verifies with `timingSafeEqual` + length guard. Configure header names via `FORWARDAUTH_HEADER_*` env vars (defaults are Authentik values). Legacy alias `AGENTPULSE_AUTHENTIK_TRUST_SECRET` accepted for one release. See `deploy/k8s/FORWARDAUTH.md` and `deploy/k8s/RUNBOOK-secrets-rotation.md`.
+  - **Session bridge** (`src/server/auth/forwardauth-bridge.ts`, AGEN-5): on the first forwardauth-gated request, mints an `ap_session` cookie (8h default; `AGENTPULSE_SSO_SESSION_DURATION_MS`) so `/auth/me` and WS upgrades resolve the SSO identity through the existing cookie step. `auth_sessions` has four additive columns: `auth_source` (text, not-null, default `"local"`), `sso_subject` (nullable), `sso_username` (nullable), `provider` (nullable). SSO sessions are non-admin (`source:"forwardauth"`, `role:null`); no shadow `users` row is created.
+  - **`/auth/me` is un-forwardauth'd by design**: listed in the IngressRoute without the middleware chain. Moving it behind forwardauth would break local-auth fallback and double-set the cookie via the bridge. `Bearer ap_*` is authoritative when present — valid key → `api_key` identity; invalid/unknown key → 401 (the cookie is never consulted as fallback).
+  - **Supervisor split**: dashboard-management routes at `/api/v1/admin/supervisors/*` (not in the IngressRoute exemption list; falls through to the forwardauth catch-all for live IdP revocation). Machine-agent routes remain at edge-public `/api/v1/supervisors/*` with supervisor-credential auth.
 
 ### Relay (for remote server users)
 Claude Code blocks hooks to non-localhost IPs. The relay (`scripts/relay.ts`) runs on localhost and forwards events to the remote server. LaunchAgent auto-starts it on macOS login.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM oven/bun:1 AS deps
+FROM oven/bun:1.3.12 AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile --production
 
-FROM oven/bun:1 AS builder
+FROM oven/bun:1.3.12 AS builder
 WORKDIR /app
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 COPY . .
 RUN bun run build
 
-FROM oven/bun:1-slim AS runner
+FROM oven/bun:1.3.12-slim AS runner
 WORKDIR /app
 
 # Pre-create runtime-writable directories and hand them to the non-root

--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ AgentPulse ships a `Content-Security-Policy-Report-Only` header (as of 0.3.0). T
 | `FORWARDAUTH_HEADER_UID` | `X-Authentik-Uid` | Header carrying the unique user identifier. |
 | `FORWARDAUTH_HEADER_VERIFY` | `X-Authentik-Verify` | Header used to carry the trust secret from Traefik to AgentPulse. |
 | `FORWARDAUTH_HEADER_STRIP_PREFIX` | `X-Authentik-` | Prefix of IdP identity headers stripped before forwardauth runs. |
+| `AGENTPULSE_SSO_SESSION_DURATION_MS` | `28800000` (8 h) | Lifetime in milliseconds of the `ap_session` cookie minted by the forwardauth session bridge. Local-auth sessions use a separate 30-day TTL and are unaffected. |
 | `LOG_LEVEL` | `info` | `debug`, `info`, `warn`, `error` |
 | `AGENTPULSE_TELEMETRY` | `on` | Set `off` to disable anonymous telemetry |
 | `DO_NOT_TRACK` | | Set `1` to disable telemetry (standard) |

--- a/deploy/k8s/06-middleware.yaml
+++ b/deploy/k8s/06-middleware.yaml
@@ -108,8 +108,15 @@ metadata:
 spec:
   headers:
     customRequestHeaders:
-      # Replace with the value of FORWARDAUTH_TRUST_SECRET via your
-      # private overlay — do NOT commit a real secret to this base manifest.
+      # CRITICAL: In Traefik, an empty string in customRequestHeaders means DELETE
+      # the header — it is NOT forwarded as an empty value. This placeholder ("") means
+      # AgentPulse never receives X-Authentik-Verify, the trust gate rejects every
+      # forwardauth request (reason: missing_verify_header), and SSO is completely
+      # non-functional. A real value MUST be injected via your private overlay patch
+      # (never committed to this base manifest).
+      #
+      # See deploy/k8s/FORWARDAUTH.md → Step 3 for the overlay pattern.
+      # See deploy/k8s/RUNBOOK-secrets-rotation.md for rotation procedure.
       X-Authentik-Verify: ""
 ---
 apiVersion: traefik.io/v1alpha1

--- a/deploy/k8s/07-ingressroute.yaml
+++ b/deploy/k8s/07-ingressroute.yaml
@@ -77,6 +77,48 @@ spec:
         - name: agentpulse
           port: 3000
 
+    # Browser-client auth paths — mirror of the /api/v1/auth/* exemptions above.
+    # The SPA uses APP_API_BASE = "/app-api/v1" (src/web/lib/paths.ts) so its
+    # auth introspection and login/logout endpoints arrive at /app-api/v1/auth/*.
+    # Without these rules they fall through to the catch-all forwardauth chain,
+    # which breaks local-auth login (Authentik returns 302 on the login page
+    # fetch) and defeats the bridge cookie design (the un-forwardauth'd /auth/me
+    # must resolve the cookie, not receive inline forwardauth headers).
+    - match: Host(`agentpulse.example.com`) && Path(`/app-api/v1/auth/me`)
+      kind: Rule
+      services:
+        - name: agentpulse
+          port: 3000
+
+    - match: Host(`agentpulse.example.com`) && Path(`/app-api/v1/auth/login`)
+      kind: Rule
+      services:
+        - name: agentpulse
+          port: 3000
+
+    - match: Host(`agentpulse.example.com`) && Path(`/app-api/v1/auth/logout`)
+      kind: Rule
+      services:
+        - name: agentpulse
+          port: 3000
+
+    - match: Host(`agentpulse.example.com`) && Path(`/app-api/v1/auth/signup`)
+      kind: Rule
+      services:
+        - name: agentpulse
+          port: 3000
+
+    # Browser WebSocket — exempt from forwardauth so the app-layer cookie gate
+    # (getAuthUserFromHeaders step-3, ap_session) can survive IdP session lapse
+    # within the 8h cookie TTL. Browser WS upgrades cannot follow 302 redirects;
+    # Traefik-level forwardauth rejection is a hard disconnect. Auth is enforced
+    # in-process (src/server/index.ts), where an invalid/absent cookie returns 401.
+    - match: Host(`agentpulse.example.com`) && Path(`/app-api/v1/ws`)
+      kind: Rule
+      services:
+        - name: agentpulse
+          port: 3000
+
     # Supervisors AGENT surface — public at the edge; covers machine-agent endpoints only.
     # Supervisor agents run on remote machines and cannot hold an SSO session.
     # Each endpoint carries explicit in-process auth:

--- a/deploy/k8s/07-ingressroute.yaml
+++ b/deploy/k8s/07-ingressroute.yaml
@@ -77,17 +77,18 @@ spec:
         - name: agentpulse
           port: 3000
 
-    # Supervisors surface — public at the edge; per-handler auth enforced server-side.
+    # Supervisors AGENT surface — public at the edge; covers machine-agent endpoints only.
     # Supervisor agents run on remote machines and cannot hold an SSO session.
     # Each endpoint carries explicit in-process auth:
-    #   GET  /supervisors, /supervisors/:id, POST /enroll, /rotate, /revoke
-    #        → requireAuth() (dashboard API-key or SSO session)
     #   POST /register → enrollment token or supervisor credential (checked in-handler)
     #   POST /heartbeat, /launches/claim, /launches/:id/status, /managed-session-state,
     #        /managed-sessions/:id/events, /provider-sync, /control-actions/*
     #        → requireSupervisorAuth() (supervisor credential token)
-    # The API-key Bearer bypass rule above covers requireAuth() callers that use ap_ keys.
     # requireSupervisorAuth() uses a separate supervisor token scheme; no SSO session needed.
+    #
+    # DASHBOARD MANAGEMENT endpoints (GET /supervisors, /supervisors/:id, POST /enroll,
+    # /rotate, /revoke) have moved to /api/v1/admin/supervisors/* which is intentionally
+    # NOT listed here and falls through to the catch-all forwardauth rule below.
     - match: Host(`agentpulse.example.com`) && PathPrefix(`/api/v1/supervisors`)
       kind: Rule
       services:

--- a/deploy/k8s/FORWARDAUTH.md
+++ b/deploy/k8s/FORWARDAUTH.md
@@ -41,6 +41,92 @@ only present on requests that have already cleared the IdP gate.
 
 ---
 
+## Session bridge
+
+After a request passes the forwardauth trust gate, `bridgeForwardauthSession`
+(`src/server/auth/forwardauth-bridge.ts`) mints an `ap_session` cookie so
+`/api/v1/auth/me` and WebSocket upgrades — which deliberately bypass forwardauth in
+the IngressRoute — can resolve the SSO identity through the existing cookie step.
+
+Ticket: AGEN-5
+Commits: c5b68e0 (schema), 801f5cc (resolver+Bearer), 7f650de (route-split), 813921c (bridge), 6e02f85 (frontend+warning)
+
+### Why /auth/me stays off forwardauth
+
+`/api/v1/auth/me`, `/auth/login`, `/auth/logout`, and `/auth/signup` have their own
+IngressRoute rules without the forwardauth middleware chain, by design:
+- The login page needs to reach `/auth/me` unauthenticated to render correctly.
+- Local-auth (username/password) fallback must remain reachable for non-SSO users.
+
+These endpoints MUST stay off forwardauth. If moved behind it, the bridge and the
+auth handler would both set `ap_session` on the same request, silently breaking SSO.
+
+### Cookie attributes
+
+The `ap_session` cookie minted by the bridge:
+- `HttpOnly`, `Secure` (production only), `SameSite=Lax`, `Path=/`
+- `MaxAge` = `AGENTPULSE_SSO_SESSION_DURATION_MS / 1000` (default 28800 s = 8 h)
+
+No sliding renewal. The expiry is fixed at mint time. After expiry, the next navigation
+through the forwardauth catch-all re-mints a fresh session. Tune the TTL with
+`AGENTPULSE_SSO_SESSION_DURATION_MS` (milliseconds). Shorter TTL bounds the
+post-IdP-revocation window; longer TTL reduces re-mint frequency.
+
+Mint is skipped when the existing cookie already matches the current subject and
+provider (resolve-then-mint). All other cases — no cookie, expired, different subject,
+different provider, local session — result in a fresh mint.
+
+### SSO session properties
+
+SSO sessions are non-admin. `/auth/me` returns:
+
+```json
+{ "source": "forwardauth", "provider": "<FORWARDAUTH_PROVIDER value>", "role": null }
+```
+
+No shadow `users` row is created. Identity is stored on the `auth_sessions` row via
+four additive columns (`auth_source`, `sso_subject`, `sso_username`, `provider`). Local
+sessions see `auth_source = "local"` and null SSO columns.
+
+### Supervisor endpoint split
+
+Management endpoints (list, get, enroll, rotate, revoke) are at
+`/api/v1/admin/supervisors/*`. This prefix is not in the IngressRoute exemption list,
+so it falls through to the forwardauth catch-all: SSO browser requests carry live IdP
+headers, giving immediate revocation effect.
+
+Machine-agent endpoints (register, heartbeat, launch/claim, control-actions) remain at
+edge-public `/api/v1/supervisors/*` with supervisor-credential auth. Remote machines
+cannot hold an SSO session cookie; they must never be behind forwardauth.
+
+### Bearer API key precedence
+
+When a request presents `Authorization: Bearer ap_*`, that credential is the only one
+consulted:
+- Valid key → `{ source: "api_key" }`
+- Invalid or unknown key → **401; the cookie is not consulted**
+
+This prevents a stale or bridged `ap_session` cookie from authorizing a request that
+passed Traefik's edge Bearer-bypass rule with an invalid key.
+
+### WebSocket limitation
+
+WS upgrades use the `ap_session` cookie minted during the prior SPA document load. The
+bridge does not run on WS upgrades (no HTML response to set the cookie on). If the SSO
+cookie expires while a WS session is open, the WS session continues until disconnect;
+it is not re-validated mid-stream.
+
+### Trust secret requirement
+
+The bridge only mints when the trust gate passes. If `agentpulse-inject-verify` is
+deployed with the base placeholder (`X-Authentik-Verify: ""`), Traefik interprets the
+empty string as "delete this header" — AgentPulse never receives the verify header, the
+trust gate rejects every request, and no cookie is minted. SSO is non-functional
+regardless of any code changes. See Step 3 in the Authentik section below for the
+private overlay injection pattern.
+
+---
+
 ## Env vars
 
 Configure these in `agentpulse-secrets` (for the trust secret) and `agentpulse-config`

--- a/deploy/k8s/RUNBOOK-secrets-rotation.md
+++ b/deploy/k8s/RUNBOOK-secrets-rotation.md
@@ -8,9 +8,12 @@ The deprecated alias `AGENTPULSE_AUTHENTIK_TRUST_SECRET` is accepted for one
 release and is bound to the same Kubernetes Secret field. Operators using the
 legacy name do not need to rename their secret — but doing so now avoids confusion.
 
-**Traefik holds no part of this secret.** Rotation only touches the IdP configuration
-and AgentPulse. Brief downtime (one pod restart) is expected and acceptable. Zero-
-downtime rotation is out of scope for homelab deployments.
+**Traefik holds this secret** via the `agentpulse-inject-verify` middleware, patched
+into your private overlay (`deploy/k8s-homelab/middleware-patch.yaml`). Rotation must
+update BOTH the `agentpulse-secrets` Kubernetes Secret AND the `agentpulse-inject-verify`
+overlay patch with identical values — if they diverge, the trust gate rejects every
+forwardauth request and SSO breaks. Brief downtime (one pod restart) is expected and
+acceptable. Zero-downtime rotation is out of scope for homelab deployments.
 
 See `deploy/k8s/FORWARDAUTH.md` for the initial setup and the full explanation
 of how the header trust gate works.

--- a/drizzle/postgres/0001_large_agent_brand.sql
+++ b/drizzle/postgres/0001_large_agent_brand.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "auth_sessions" ADD COLUMN "auth_source" text DEFAULT 'local' NOT NULL;--> statement-breakpoint
+ALTER TABLE "auth_sessions" ADD COLUMN "sso_subject" text;--> statement-breakpoint
+ALTER TABLE "auth_sessions" ADD COLUMN "sso_username" text;--> statement-breakpoint
+ALTER TABLE "auth_sessions" ADD COLUMN "provider" text;

--- a/drizzle/postgres/meta/0001_snapshot.json
+++ b/drizzle/postgres/meta/0001_snapshot.json
@@ -1,0 +1,2989 @@
+{
+	"id": "e9e825ed-95d5-4042-a4ba-89dc3301cbfd",
+	"prevId": "14140de5-734c-41af-b922-c1808c6d3186",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.ai_action_requests": {
+			"name": "ai_action_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'awaiting_reply'"
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"question": {
+					"name": "question",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ask_thread_id": {
+					"name": "ask_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resolved_at": {
+					"name": "resolved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resolved_by": {
+					"name": "resolved_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"result_event_id": {
+					"name": "result_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_daily_spend": {
+			"name": "ai_daily_spend",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"spend_cents": {
+					"name": "spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ai_daily_spend_user_id_date_pk": {
+					"name": "ai_daily_spend_user_id_date_pk",
+					"columns": ["user_id", "date"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_hitl_requests": {
+			"name": "ai_hitl_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'awaiting_reply'"
+				},
+				"reply_kind": {
+					"name": "reply_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reply_text": {
+					"name": "reply_text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_ai_hitl_requests_session_status": {
+					"name": "idx_ai_hitl_requests_session_status",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_ai_hitl_requests_open_per_session": {
+					"name": "idx_ai_hitl_requests_open_per_session",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"ai_hitl_requests\".\"status\" = 'awaiting_reply'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ai_hitl_requests_session_id_sessions_session_id_fk": {
+					"name": "ai_hitl_requests_session_id_sessions_session_id_fk",
+					"tableFrom": "ai_hitl_requests",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_inbox_snoozes": {
+			"name": "ai_inbox_snoozes",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snoozed_until": {
+					"name": "snoozed_until",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_pending_project_drafts": {
+			"name": "ai_pending_project_drafts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"ask_thread_id": {
+					"name": "ask_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'add_project'"
+				},
+				"draft_fields": {
+					"name": "draft_fields",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_question": {
+					"name": "next_question",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'drafting'"
+				},
+				"action_request_id": {
+					"name": "action_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_pending_project_drafts_thread": {
+					"name": "idx_pending_project_drafts_thread",
+					"columns": [
+						{
+							"expression": "ask_thread_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"ai_pending_project_drafts\".\"status\" IN ('drafting', 'pending_approval')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_qa_cache": {
+			"name": "ai_qa_cache",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"question_hash": {
+					"name": "question_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"response": {
+					"name": "response",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_event_id": {
+					"name": "last_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cached_at": {
+					"name": "cached_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"idx_qa_cache_session_question": {
+					"name": "idx_qa_cache_session_question",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "question_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_watcher_runs": {
+			"name": "ai_watcher_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"trigger_event_id": {
+					"name": "trigger_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trigger_kind": {
+					"name": "trigger_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"dedupe_key": {
+					"name": "dedupe_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lease_owner": {
+					"name": "lease_owner",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lease_expires_at": {
+					"name": "lease_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"attempt_count": {
+					"name": "attempt_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"last_error_sub_type": {
+					"name": "last_error_sub_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_ai_watcher_runs_status_lease": {
+					"name": "idx_ai_watcher_runs_status_lease",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "lease_expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_ai_watcher_runs_session_created": {
+					"name": "idx_ai_watcher_runs_session_created",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_ai_watcher_runs_open_per_session": {
+					"name": "idx_ai_watcher_runs_open_per_session",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"ai_watcher_runs\".\"status\" IN ('queued', 'claimed', 'running')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ai_watcher_runs_session_id_sessions_session_id_fk": {
+					"name": "ai_watcher_runs_session_id_sessions_session_id_fk",
+					"tableFrom": "ai_watcher_runs",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_keys": {
+			"name": "api_keys",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key_hash": {
+					"name": "key_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key_prefix": {
+					"name": "key_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"last_used_at": {
+					"name": "last_used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"api_keys_key_hash_unique": {
+					"name": "api_keys_key_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["key_hash"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ask_messages": {
+			"name": "ask_messages",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"thread_id": {
+					"name": "thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"context_session_ids": {
+					"name": "context_session_ids",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_in": {
+					"name": "tokens_in",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_out": {
+					"name": "tokens_out",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ask_threads": {
+			"name": "ask_threads",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'web'"
+				},
+				"telegram_chat_id": {
+					"name": "telegram_chat_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_ask_threads_updated": {
+					"name": "idx_ask_threads_updated",
+					"columns": [
+						{
+							"expression": "updated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"ask_threads\".\"archived_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_ask_threads_telegram_chat": {
+					"name": "idx_ask_threads_telegram_chat",
+					"columns": [
+						{
+							"expression": "telegram_chat_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"ask_threads\".\"telegram_chat_id\" IS NOT NULL AND \"ask_threads\".\"archived_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.auth_sessions": {
+			"name": "auth_sessions",
+			"schema": "",
+			"columns": {
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"auth_source": {
+					"name": "auth_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'local'"
+				},
+				"sso_subject": {
+					"name": "sso_subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sso_username": {
+					"name": "sso_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.control_actions": {
+			"name": "control_actions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"launch_request_id": {
+					"name": "launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action_type": {
+					"name": "action_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"requested_by": {
+					"name": "requested_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata_json": {
+					"name": "metadata_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_by_supervisor_id": {
+					"name": "claimed_by_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"control_actions_session_id_sessions_session_id_fk": {
+					"name": "control_actions_session_id_sessions_session_id_fk",
+					"tableFrom": "control_actions",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "events_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "2147483647",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'observed_hook'"
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_noise": {
+					"name": "is_noise",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"provider_event_type": {
+					"name": "provider_event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_name": {
+					"name": "tool_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_input": {
+					"name": "tool_input",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_response": {
+					"name": "tool_response",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload": {
+					"name": "raw_payload",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"events_session_id_sessions_session_id_fk": {
+					"name": "events_session_id_sessions_session_id_fk",
+					"tableFrom": "events",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.launch_requests": {
+			"name": "launch_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"template_id": {
+					"name": "template_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"launch_correlation_id": {
+					"name": "launch_correlation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_instructions": {
+					"name": "base_instructions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"task_prompt": {
+					"name": "task_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approval_policy": {
+					"name": "approval_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sandbox_mode": {
+					"name": "sandbox_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"requested_launch_mode": {
+					"name": "requested_launch_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'interactive_terminal'"
+				},
+				"env_json": {
+					"name": "env_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::json"
+				},
+				"launch_spec_json": {
+					"name": "launch_spec_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::json"
+				},
+				"requested_by": {
+					"name": "requested_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"requested_supervisor_id": {
+					"name": "requested_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"routing_policy": {
+					"name": "routing_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resolved_supervisor_id": {
+					"name": "resolved_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"routing_decision_json": {
+					"name": "routing_decision_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_by_supervisor_id": {
+					"name": "claimed_by_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claim_token": {
+					"name": "claim_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"validation_warnings_json": {
+					"name": "validation_warnings_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::json"
+				},
+				"validation_summary": {
+					"name": "validation_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatch_started_at": {
+					"name": "dispatch_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatch_finished_at": {
+					"name": "dispatch_finished_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"awaiting_session_deadline_at": {
+					"name": "awaiting_session_deadline_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pid": {
+					"name": "pid",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_launch_metadata_json": {
+					"name": "provider_launch_metadata_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retry_of_launch_request_id": {
+					"name": "retry_of_launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_session_id": {
+					"name": "parent_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"desired_display_name": {
+					"name": "desired_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"launch_requests_launch_correlation_id_unique": {
+					"name": "launch_requests_launch_correlation_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["launch_correlation_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.llm_providers": {
+			"name": "llm_providers",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'local'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_url": {
+					"name": "base_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"credential_ciphertext": {
+					"name": "credential_ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_hint": {
+					"name": "credential_hint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_default": {
+					"name": "is_default",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.managed_sessions": {
+			"name": "managed_sessions",
+			"schema": "",
+			"columns": {
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"launch_request_id": {
+					"name": "launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_session_id": {
+					"name": "provider_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_thread_id": {
+					"name": "provider_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"managed_state": {
+					"name": "managed_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"correlation_source": {
+					"name": "correlation_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"desired_thread_title": {
+					"name": "desired_thread_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_thread_title": {
+					"name": "provider_thread_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_sync_state": {
+					"name": "provider_sync_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"provider_sync_error": {
+					"name": "provider_sync_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_provider_sync_at": {
+					"name": "last_provider_sync_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_protocol_version": {
+					"name": "provider_protocol_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_capability_snapshot_json": {
+					"name": "provider_capability_snapshot_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"active_control_action_id": {
+					"name": "active_control_action_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"control_lock_expires_at": {
+					"name": "control_lock_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"host_name": {
+					"name": "host_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"host_affinity_reason": {
+					"name": "host_affinity_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"managed_sessions_session_id_sessions_session_id_fk": {
+					"name": "managed_sessions_session_id_sessions_session_id_fk",
+					"tableFrom": "managed_sessions",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.notification_channels": {
+			"name": "notification_channels",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'local'"
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_ciphertext": {
+					"name": "credential_ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"config_json": {
+					"name": "config_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"verified_at": {
+					"name": "verified_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_alert_rule_fires": {
+			"name": "project_alert_rule_fires",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"rule_id": {
+					"name": "rule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fired_at": {
+					"name": "fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_alert_rule_fires_rule_session": {
+					"name": "idx_alert_rule_fires_rule_session",
+					"columns": [
+						{
+							"expression": "rule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_alert_rules": {
+			"name": "project_alert_rules",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rule_type": {
+					"name": "rule_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"daily_token_spend_cents": {
+					"name": "daily_token_spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"daily_token_spend_date": {
+					"name": "daily_token_spend_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_evaluated_event_id": {
+					"name": "last_evaluated_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_project_alert_rules_project": {
+					"name": "idx_project_alert_rules_project",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"project_alert_rules\".\"is_active\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"github_repo_url": {
+					"name": "github_repo_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_agent_type": {
+					"name": "default_agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_model": {
+					"name": "default_model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_launch_mode": {
+					"name": "default_launch_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_favorite": {
+					"name": "is_favorite",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"projects_name_unique": {
+					"name": "projects_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session_templates": {
+			"name": "session_templates",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_instructions": {
+					"name": "base_instructions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"task_prompt": {
+					"name": "task_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approval_policy": {
+					"name": "approval_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sandbox_mode": {
+					"name": "sandbox_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::json"
+				},
+				"tags": {
+					"name": "tags",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::json"
+				},
+				"is_favorite": {
+					"name": "is_favorite",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"template_project_overrides": {
+					"name": "template_project_overrides",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_session_templates_project_id": {
+					"name": "idx_session_templates_project_id",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"session_templates\".\"project_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sessions": {
+			"name": "sessions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"transcript_path": {
+					"name": "transcript_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"semantic_status": {
+					"name": "semantic_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_task": {
+					"name": "current_task",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"plan_summary": {
+					"name": "plan_summary",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_tool_uses": {
+					"name": "total_tool_uses",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"is_working": {
+					"name": "is_working",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_pinned": {
+					"name": "is_pinned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"git_branch": {
+					"name": "git_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claude_md_content": {
+					"name": "claude_md_content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claude_md_path": {
+					"name": "claude_md_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claude_md_checksum": {
+					"name": "claude_md_checksum",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claude_md_updated_at": {
+					"name": "claude_md_updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "''"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_archived": {
+					"name": "is_archived",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"watcher_state": {
+					"name": "watcher_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"watcher_last_run_at": {
+					"name": "watcher_last_run_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"watcher_last_user_prompt_at": {
+					"name": "watcher_last_user_prompt_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ai_spend_cents": {
+					"name": "ai_spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"sessions_session_id_unique": {
+					"name": "sessions_session_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["session_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.settings": {
+			"name": "settings",
+			"schema": "",
+			"columns": {
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.supervisor_credentials": {
+			"name": "supervisor_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token_prefix": {
+					"name": "token_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_used_at": {
+					"name": "last_used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"supervisor_credentials_supervisor_id_unique": {
+					"name": "supervisor_credentials_supervisor_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["supervisor_id"]
+				},
+				"supervisor_credentials_token_hash_unique": {
+					"name": "supervisor_credentials_token_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token_hash"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.supervisor_enrollment_tokens": {
+			"name": "supervisor_enrollment_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token_prefix": {
+					"name": "token_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"used_at": {
+					"name": "used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"supervisor_enrollment_tokens_token_hash_unique": {
+					"name": "supervisor_enrollment_tokens_token_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token_hash"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.supervisors": {
+			"name": "supervisors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"host_name": {
+					"name": "host_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform": {
+					"name": "platform",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"arch": {
+					"name": "arch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"capabilities_json": {
+					"name": "capabilities_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::json"
+				},
+				"trusted_roots_json": {
+					"name": "trusted_roots_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::json"
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'connected'"
+				},
+				"capability_schema_version": {
+					"name": "capability_schema_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"config_schema_version": {
+					"name": "config_schema_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"last_heartbeat_at": {
+					"name": "last_heartbeat_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"heartbeat_lease_expires_at": {
+					"name": "heartbeat_lease_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP + INTERVAL '90 seconds'"
+				},
+				"enrollment_state": {
+					"name": "enrollment_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"disabled_at": {
+					"name": "disabled_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_login_at": {
+					"name": "last_login_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_username_unique": {
+					"name": "users_username_unique",
+					"nullsNotDistinct": false,
+					"columns": ["username"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.watcher_configs": {
+			"name": "watcher_configs",
+			"schema": "",
+			"columns": {
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"policy": {
+					"name": "policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ask_always'"
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_continuations": {
+					"name": "max_continuations",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 10
+				},
+				"continuations_used": {
+					"name": "continuations_used",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"max_daily_cents": {
+					"name": "max_daily_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_prompt": {
+					"name": "system_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"watcher_configs_session_id_sessions_session_id_fk": {
+					"name": "watcher_configs_session_id_sessions_session_id_fk",
+					"tableFrom": "watcher_configs",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.watcher_proposals": {
+			"name": "watcher_proposals",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"decision": {
+					"name": "decision",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_prompt": {
+					"name": "next_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"report_summary": {
+					"name": "report_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_response_json": {
+					"name": "raw_response_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trigger_event_id": {
+					"name": "trigger_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_in": {
+					"name": "tokens_in",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"tokens_out": {
+					"name": "tokens_out",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"cost_cents": {
+					"name": "cost_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"usage_estimated": {
+					"name": "usage_estimated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"error_sub_type": {
+					"name": "error_sub_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"watcher_proposals_session_id_sessions_session_id_fk": {
+					"name": "watcher_proposals_session_id_sessions_session_id_fk",
+					"tableFrom": "watcher_proposals",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/postgres/meta/_journal.json
+++ b/drizzle/postgres/meta/_journal.json
@@ -8,6 +8,13 @@
 			"when": 1777965217898,
 			"tag": "0000_even_tattoo",
 			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1782762924855,
+			"tag": "0001_large_agent_brand",
+			"breakpoints": true
 		}
 	]
 }

--- a/drizzle/sqlite/0001_true_misty_knight.sql
+++ b/drizzle/sqlite/0001_true_misty_knight.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `auth_sessions` ADD `auth_source` text DEFAULT 'local' NOT NULL;--> statement-breakpoint
+ALTER TABLE `auth_sessions` ADD `sso_subject` text;--> statement-breakpoint
+ALTER TABLE `auth_sessions` ADD `sso_username` text;--> statement-breakpoint
+ALTER TABLE `auth_sessions` ADD `provider` text;

--- a/drizzle/sqlite/meta/0001_snapshot.json
+++ b/drizzle/sqlite/meta/0001_snapshot.json
@@ -1,0 +1,3010 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "3a9cb62c-1512-4d69-a960-6f76f59b65b6",
+	"prevId": "d4f65a6d-d266-4764-9799-dbd52e47d8ae",
+	"tables": {
+		"ai_action_requests": {
+			"name": "ai_action_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'awaiting_reply'"
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"question": {
+					"name": "question",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"payload": {
+					"name": "payload",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ask_thread_id": {
+					"name": "ask_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolved_at": {
+					"name": "resolved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolved_by": {
+					"name": "resolved_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"result_event_id": {
+					"name": "result_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_daily_spend": {
+			"name": "ai_daily_spend",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spend_cents": {
+					"name": "spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ai_daily_spend_user_id_date_pk": {
+					"columns": ["user_id", "date"],
+					"name": "ai_daily_spend_user_id_date_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_hitl_requests": {
+			"name": "ai_hitl_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'awaiting_reply'"
+				},
+				"reply_kind": {
+					"name": "reply_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reply_text": {
+					"name": "reply_text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_inbox_snoozes": {
+			"name": "ai_inbox_snoozes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snoozed_until": {
+					"name": "snoozed_until",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_pending_project_drafts": {
+			"name": "ai_pending_project_drafts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ask_thread_id": {
+					"name": "ask_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'add_project'"
+				},
+				"draft_fields": {
+					"name": "draft_fields",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"next_question": {
+					"name": "next_question",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'drafting'"
+				},
+				"action_request_id": {
+					"name": "action_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_qa_cache": {
+			"name": "ai_qa_cache",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"question_hash": {
+					"name": "question_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"response": {
+					"name": "response",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_event_id": {
+					"name": "last_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cached_at": {
+					"name": "cached_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_qa_cache_session_question": {
+					"name": "idx_qa_cache_session_question",
+					"columns": ["session_id", "question_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_watcher_runs": {
+			"name": "ai_watcher_runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"trigger_event_id": {
+					"name": "trigger_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"trigger_kind": {
+					"name": "trigger_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'queued'"
+				},
+				"dedupe_key": {
+					"name": "dedupe_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lease_owner": {
+					"name": "lease_owner",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lease_expires_at": {
+					"name": "lease_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"attempt_count": {
+					"name": "attempt_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"last_error_sub_type": {
+					"name": "last_error_sub_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"api_keys": {
+			"name": "api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"key_hash": {
+					"name": "key_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"key_prefix": {
+					"name": "key_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"last_used_at": {
+					"name": "last_used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"api_keys_key_hash_unique": {
+					"name": "api_keys_key_hash_unique",
+					"columns": ["key_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ask_messages": {
+			"name": "ask_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"thread_id": {
+					"name": "thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"context_session_ids": {
+					"name": "context_session_ids",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_in": {
+					"name": "tokens_in",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_out": {
+					"name": "tokens_out",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ask_threads": {
+			"name": "ask_threads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'web'"
+				},
+				"telegram_chat_id": {
+					"name": "telegram_chat_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"auth_sessions": {
+			"name": "auth_sessions",
+			"columns": {
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"auth_source": {
+					"name": "auth_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'local'"
+				},
+				"sso_subject": {
+					"name": "sso_subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sso_username": {
+					"name": "sso_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"control_actions": {
+			"name": "control_actions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"launch_request_id": {
+					"name": "launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action_type": {
+					"name": "action_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"requested_by": {
+					"name": "requested_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'queued'"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata_json": {
+					"name": "metadata_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claimed_by_supervisor_id": {
+					"name": "claimed_by_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"event_embeddings": {
+			"name": "event_embeddings",
+			"columns": {
+				"event_id": {
+					"name": "event_id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"dim": {
+					"name": "dim",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"vector": {
+					"name": "vector",
+					"type": "blob",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"events": {
+			"name": "events",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'observed_hook'"
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_noise": {
+					"name": "is_noise",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"provider_event_type": {
+					"name": "provider_event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tool_name": {
+					"name": "tool_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tool_input": {
+					"name": "tool_input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tool_response": {
+					"name": "tool_response",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_payload": {
+					"name": "raw_payload",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"events_session_id_sessions_session_id_fk": {
+					"name": "events_session_id_sessions_session_id_fk",
+					"tableFrom": "events",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"launch_requests": {
+			"name": "launch_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_id": {
+					"name": "template_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"launch_correlation_id": {
+					"name": "launch_correlation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_instructions": {
+					"name": "base_instructions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"task_prompt": {
+					"name": "task_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approval_policy": {
+					"name": "approval_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandbox_mode": {
+					"name": "sandbox_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"requested_launch_mode": {
+					"name": "requested_launch_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'interactive_terminal'"
+				},
+				"env_json": {
+					"name": "env_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"launch_spec_json": {
+					"name": "launch_spec_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"requested_by": {
+					"name": "requested_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"requested_supervisor_id": {
+					"name": "requested_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"routing_policy": {
+					"name": "routing_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolved_supervisor_id": {
+					"name": "resolved_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"routing_decision_json": {
+					"name": "routing_decision_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claimed_by_supervisor_id": {
+					"name": "claimed_by_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claim_token": {
+					"name": "claim_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'draft'"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"validation_warnings_json": {
+					"name": "validation_warnings_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"validation_summary": {
+					"name": "validation_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dispatch_started_at": {
+					"name": "dispatch_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dispatch_finished_at": {
+					"name": "dispatch_finished_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awaiting_session_deadline_at": {
+					"name": "awaiting_session_deadline_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pid": {
+					"name": "pid",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_launch_metadata_json": {
+					"name": "provider_launch_metadata_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"retry_of_launch_request_id": {
+					"name": "retry_of_launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_session_id": {
+					"name": "parent_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"desired_display_name": {
+					"name": "desired_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"launch_requests_launch_correlation_id_unique": {
+					"name": "launch_requests_launch_correlation_id_unique",
+					"columns": ["launch_correlation_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"llm_providers": {
+			"name": "llm_providers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'local'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_url": {
+					"name": "base_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"credential_ciphertext": {
+					"name": "credential_ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"credential_hint": {
+					"name": "credential_hint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_default": {
+					"name": "is_default",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"managed_sessions": {
+			"name": "managed_sessions",
+			"columns": {
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"launch_request_id": {
+					"name": "launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_session_id": {
+					"name": "provider_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_thread_id": {
+					"name": "provider_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"managed_state": {
+					"name": "managed_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"correlation_source": {
+					"name": "correlation_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"desired_thread_title": {
+					"name": "desired_thread_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_thread_title": {
+					"name": "provider_thread_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_sync_state": {
+					"name": "provider_sync_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"provider_sync_error": {
+					"name": "provider_sync_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_provider_sync_at": {
+					"name": "last_provider_sync_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_protocol_version": {
+					"name": "provider_protocol_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_capability_snapshot_json": {
+					"name": "provider_capability_snapshot_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"active_control_action_id": {
+					"name": "active_control_action_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"control_lock_expires_at": {
+					"name": "control_lock_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"host_name": {
+					"name": "host_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"host_affinity_reason": {
+					"name": "host_affinity_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notification_channels": {
+			"name": "notification_channels",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'local'"
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"credential_ciphertext": {
+					"name": "credential_ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"config_json": {
+					"name": "config_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"verified_at": {
+					"name": "verified_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"project_alert_rule_fires": {
+			"name": "project_alert_rule_fires",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rule_id": {
+					"name": "rule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"fired_at": {
+					"name": "fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"idx_alert_rule_fires_rule_session": {
+					"name": "idx_alert_rule_fires_rule_session",
+					"columns": ["rule_id", "session_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"project_alert_rules": {
+			"name": "project_alert_rules",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rule_type": {
+					"name": "rule_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"params": {
+					"name": "params",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"daily_token_spend_cents": {
+					"name": "daily_token_spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"daily_token_spend_date": {
+					"name": "daily_token_spend_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_evaluated_event_id": {
+					"name": "last_evaluated_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"projects": {
+			"name": "projects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"github_repo_url": {
+					"name": "github_repo_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"default_agent_type": {
+					"name": "default_agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"default_model": {
+					"name": "default_model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"default_launch_mode": {
+					"name": "default_launch_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_favorite": {
+					"name": "is_favorite",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"projects_name_unique": {
+					"name": "projects_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session_templates": {
+			"name": "session_templates",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_instructions": {
+					"name": "base_instructions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"task_prompt": {
+					"name": "task_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approval_policy": {
+					"name": "approval_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandbox_mode": {
+					"name": "sandbox_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"is_favorite": {
+					"name": "is_favorite",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"template_project_overrides": {
+					"name": "template_project_overrides",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcript_path": {
+					"name": "transcript_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"semantic_status": {
+					"name": "semantic_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"current_task": {
+					"name": "current_task",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"plan_summary": {
+					"name": "plan_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"total_tool_uses": {
+					"name": "total_tool_uses",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"is_working": {
+					"name": "is_working",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"is_pinned": {
+					"name": "is_pinned",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"git_branch": {
+					"name": "git_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claude_md_content": {
+					"name": "claude_md_content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claude_md_path": {
+					"name": "claude_md_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claude_md_checksum": {
+					"name": "claude_md_checksum",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claude_md_updated_at": {
+					"name": "claude_md_updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_archived": {
+					"name": "is_archived",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"watcher_state": {
+					"name": "watcher_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"watcher_last_run_at": {
+					"name": "watcher_last_run_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"watcher_last_user_prompt_at": {
+					"name": "watcher_last_user_prompt_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ai_spend_cents": {
+					"name": "ai_spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"sessions_session_id_unique": {
+					"name": "sessions_session_id_unique",
+					"columns": ["session_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"settings": {
+			"name": "settings",
+			"columns": {
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"supervisor_credentials": {
+			"name": "supervisor_credentials",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token_prefix": {
+					"name": "token_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"last_used_at": {
+					"name": "last_used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"supervisor_credentials_supervisor_id_unique": {
+					"name": "supervisor_credentials_supervisor_id_unique",
+					"columns": ["supervisor_id"],
+					"isUnique": true
+				},
+				"supervisor_credentials_token_hash_unique": {
+					"name": "supervisor_credentials_token_hash_unique",
+					"columns": ["token_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"supervisor_enrollment_tokens": {
+			"name": "supervisor_enrollment_tokens",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token_prefix": {
+					"name": "token_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"used_at": {
+					"name": "used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"supervisor_enrollment_tokens_token_hash_unique": {
+					"name": "supervisor_enrollment_tokens_token_hash_unique",
+					"columns": ["token_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"supervisors": {
+			"name": "supervisors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"host_name": {
+					"name": "host_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"platform": {
+					"name": "platform",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"arch": {
+					"name": "arch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"version": {
+					"name": "version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"capabilities_json": {
+					"name": "capabilities_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"trusted_roots_json": {
+					"name": "trusted_roots_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'connected'"
+				},
+				"capability_schema_version": {
+					"name": "capability_schema_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"config_schema_version": {
+					"name": "config_schema_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"last_heartbeat_at": {
+					"name": "last_heartbeat_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"heartbeat_lease_expires_at": {
+					"name": "heartbeat_lease_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now', '+90 seconds'))"
+				},
+				"enrollment_state": {
+					"name": "enrollment_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'user'"
+				},
+				"disabled_at": {
+					"name": "disabled_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_login_at": {
+					"name": "last_login_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"users_username_unique": {
+					"name": "users_username_unique",
+					"columns": ["username"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"watcher_configs": {
+			"name": "watcher_configs",
+			"columns": {
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"policy": {
+					"name": "policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ask_always'"
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"max_continuations": {
+					"name": "max_continuations",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 10
+				},
+				"continuations_used": {
+					"name": "continuations_used",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"max_daily_cents": {
+					"name": "max_daily_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"system_prompt": {
+					"name": "system_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"watcher_proposals": {
+			"name": "watcher_proposals",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"decision": {
+					"name": "decision",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"next_prompt": {
+					"name": "next_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"report_summary": {
+					"name": "report_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_response_json": {
+					"name": "raw_response_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"trigger_event_id": {
+					"name": "trigger_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_in": {
+					"name": "tokens_in",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"tokens_out": {
+					"name": "tokens_out",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"cost_cents": {
+					"name": "cost_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"usage_estimated": {
+					"name": "usage_estimated",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"error_sub_type": {
+					"name": "error_sub_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/sqlite/meta/_journal.json
+++ b/drizzle/sqlite/meta/_journal.json
@@ -8,6 +8,13 @@
 			"when": 1777965178178,
 			"tag": "0000_worthless_strong_guy",
 			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1782762916771,
+			"tag": "0001_true_misty_knight",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/server/app.integration.test.ts
+++ b/src/server/app.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Real-app integration tests for src/server/app.ts.
+ *
+ * Unlike the helper-app bridge tests (forwardauth-bridge.test.ts), these import
+ * the actual exported `app` to verify bridge middleware ordering, route-level auth
+ * gating, and Bearer-precedence end-to-end on the real mounted surface.
+ *
+ * AC coverage:
+ *  M-2a  — Valid forwardauth headers on GET / → ap_session Set-Cookie from the real app.
+ *  M-2b  — POST /api/v1/admin/supervisors/enroll with valid SSO cookie
+ *           + Authorization: Bearer ap_<invalid> → 401 (bearer is authoritative, cookie ignored).
+ *  M-2c  — POST /api/v1/admin/supervisors/enroll with live forwardauth headers → 201.
+ *  M-2d  — POST /api/v1/admin/supervisors/enroll with a valid ap_ API key → 201.
+ *  AC7   — SSO ap_session logout: POST /auth/logout revokes the row server-side;
+ *           subsequent GET /auth/me with the same cookie → authenticated:false.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import "./db/__test_db.js";
+
+const { config } = await import("./config.js");
+const { initializeDatabase } = await import("./db/client.js");
+const { app } = await import("./app.js");
+const { SESSION_COOKIE_NAME, SSO_SESSION_DURATION_MS, issueSession } = await import(
+	"./services/local-auth-service.js"
+);
+const { createApiKey } = await import("./auth/api-key.js");
+
+// ─── Test configuration ──────────────────────────────────────────────────────
+
+const TEST_SECRET = "app-int-test-secret-32-chars!!!!";
+const TEST_SUBJECT = "app-int-subject";
+const TEST_USERNAME = "app-int-user";
+const TEST_PROVIDER = "authentik";
+
+function forwardauthHeaders(overrides: Record<string, string> = {}): Headers {
+	return new Headers({
+		"X-Authentik-Username": TEST_USERNAME,
+		"X-Authentik-Uid": TEST_SUBJECT,
+		"X-Authentik-Verify": TEST_SECRET,
+		...overrides,
+	});
+}
+
+function countSessionCookies(res: Response): number {
+	let count = 0;
+	res.headers.forEach((value, key) => {
+		if (key.toLowerCase() === "set-cookie" && value.startsWith(`${SESSION_COOKIE_NAME}=`)) {
+			count++;
+		}
+	});
+	return count;
+}
+
+// ─── Setup / teardown ────────────────────────────────────────────────────────
+
+const originalDisableAuth = config.disableAuth;
+const originalSecret = process.env.FORWARDAUTH_TRUST_SECRET;
+const originalProvider = process.env.FORWARDAUTH_PROVIDER;
+
+beforeAll(async () => {
+	await initializeDatabase();
+	process.env.FORWARDAUTH_TRUST_SECRET = TEST_SECRET;
+	process.env.FORWARDAUTH_PROVIDER = TEST_PROVIDER;
+	(config as Record<string, unknown>).disableAuth = false;
+	// Clear the memoised trust-secret so the just-set env var takes effect.
+	// biome-ignore lint/performance/noDelete: clear Object.defineProperty-installed own property
+	delete (config as Record<string, unknown>)._forwardauthTrustSecret;
+});
+
+afterAll(() => {
+	(config as Record<string, unknown>).disableAuth = originalDisableAuth;
+	if (originalSecret === undefined) {
+		process.env.FORWARDAUTH_TRUST_SECRET = undefined;
+	} else {
+		process.env.FORWARDAUTH_TRUST_SECRET = originalSecret;
+	}
+	if (originalProvider === undefined) {
+		process.env.FORWARDAUTH_PROVIDER = undefined;
+	} else {
+		process.env.FORWARDAUTH_PROVIDER = originalProvider;
+	}
+	// biome-ignore lint/performance/noDelete: clear memo for teardown parity
+	delete (config as Record<string, unknown>)._forwardauthTrustSecret;
+});
+
+// ─── M-2a: Bridge mounts on real app ────────────────────────────────────────
+
+describe("M-2a — real app: valid forwardauth headers on GET / → ap_session Set-Cookie", () => {
+	test("bridge middleware is wired before SPA catch-all on the exported app", async () => {
+		const res = await app.request("/", { headers: forwardauthHeaders() });
+		// GET / returns 404 in test mode (no SPA bundle), but the bridge fires on every
+		// request via app.use("*", ...) so Set-Cookie must be present regardless.
+		expect(countSessionCookies(res)).toBe(1);
+	});
+});
+
+// ─── M-2b: Bearer ap_invalid + SSO cookie → 401 ─────────────────────────────
+
+describe("M-2b — admin enroll: valid SSO cookie + Bearer ap_invalid → 401", () => {
+	test("invalid Bearer short-circuits to 401; cookie identity is not consulted", async () => {
+		const { token: ssoToken } = await issueSession({
+			userId: `sso:${TEST_SUBJECT}-m2b`,
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: `${TEST_SUBJECT}-m2b`,
+			ssoUsername: TEST_USERNAME,
+			provider: TEST_PROVIDER,
+		});
+
+		const res = await app.request("/api/v1/admin/supervisors/enroll", {
+			method: "POST",
+			headers: new Headers({
+				Cookie: `${SESSION_COOKIE_NAME}=${ssoToken}`,
+				Authorization: "Bearer ap_totallyinvalidkey00000000",
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ name: "test-supervisor-m2b" }),
+		});
+
+		expect(res.status).toBe(401);
+	});
+});
+
+// ─── M-2c: Live forwardauth headers → 201 ────────────────────────────────────
+
+describe("M-2c — admin enroll: live forwardauth headers → 201", () => {
+	test("forwardauth identity resolves via step-1 → requireAuth passes → 201 enrollment token", async () => {
+		const h = forwardauthHeaders({ "Content-Type": "application/json" });
+		const res = await app.request("/api/v1/admin/supervisors/enroll", {
+			method: "POST",
+			headers: h,
+			body: JSON.stringify({ name: "fa-supervisor-m2c" }),
+		});
+
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { token: string };
+		expect(typeof body.token).toBe("string");
+		expect(body.token.length).toBeGreaterThan(0);
+	});
+});
+
+// ─── M-2d: Valid ap_ API key → 201 ──────────────────────────────────────────
+
+describe("M-2d — admin enroll: valid ap_ API key → 201", () => {
+	test("valid ap_ Bearer key resolves as api_key source → requireAuth passes → 201", async () => {
+		const { key: apiKey } = await createApiKey("app-int-test-key");
+
+		const res = await app.request("/api/v1/admin/supervisors/enroll", {
+			method: "POST",
+			headers: new Headers({
+				Authorization: `Bearer ${apiKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ name: "api-key-supervisor-m2d" }),
+		});
+
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { token: string };
+		expect(typeof body.token).toBe("string");
+	});
+});
+
+// ─── AC7: SSO logout revokes row; /auth/me unauthenticated after ─────────────
+
+describe("AC7 — SSO ap_session logout: POST /auth/logout → row revoked → /auth/me unauthenticated", () => {
+	test("minted SSO session is revoked server-side; subsequent /auth/me with same cookie is unauthenticated", async () => {
+		const { token } = await issueSession({
+			userId: `sso:${TEST_SUBJECT}-ac7`,
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: `${TEST_SUBJECT}-ac7`,
+			ssoUsername: TEST_USERNAME,
+			provider: TEST_PROVIDER,
+		});
+
+		// Sanity: /auth/me with the cookie resolves as authenticated.
+		const me1 = await app.request("/api/v1/auth/me", {
+			headers: new Headers({ Cookie: `${SESSION_COOKIE_NAME}=${token}` }),
+		});
+		const body1 = (await me1.json()) as { authenticated: boolean };
+		expect(body1.authenticated).toBe(true);
+
+		// POST /auth/logout — revokes the session row server-side.
+		const logoutRes = await app.request("/api/v1/auth/logout", {
+			method: "POST",
+			headers: new Headers({ Cookie: `${SESSION_COOKIE_NAME}=${token}` }),
+		});
+		expect(logoutRes.status).toBe(200);
+
+		// Same (now-revoked) cookie → /auth/me must return unauthenticated.
+		const me2 = await app.request("/api/v1/auth/me", {
+			headers: new Headers({ Cookie: `${SESSION_COOKIE_NAME}=${token}` }),
+		});
+		const body2 = (await me2.json()) as { authenticated: boolean };
+		expect(body2.authenticated).toBe(false);
+	});
+});

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -44,7 +44,7 @@ import { searchRouter } from "./routes/search.js";
 import { sessionsRouter } from "./routes/sessions.js";
 import { settingsRouter } from "./routes/settings.js";
 import { setup as setupRoute } from "./routes/setup.js";
-import { supervisorsRouter } from "./routes/supervisors.js";
+import { supervisorsAdminRouter, supervisorsAgentRouter } from "./routes/supervisors.js";
 import { templatesRouter } from "./routes/templates.js";
 
 export const app = new Hono();
@@ -64,7 +64,13 @@ api.route("/v1", sessionsRouter);
 api.route("/v1", settingsRouter);
 api.route("/v1", templatesRouter);
 api.route("/v1", projectsRouter);
-api.route("/v1", supervisorsRouter);
+// Agent endpoints — edge-public (PathPrefix /api/v1/supervisors is exempt from
+// forwardauth in IngressRoute). Each handler carries its own supervisor-token
+// or enrollment-token auth; remote machines cannot hold an SSO session.
+api.route("/v1", supervisorsAgentRouter);
+// Management endpoints — forwardauth-gated via /api/v1/admin/* which is NOT
+// in the IngressRoute exemption list and falls through to the catch-all rule.
+api.route("/v1/admin", supervisorsAdminRouter);
 api.route("/v1", launchesRouter);
 // AI control-plane: split from the monolithic ai.ts into 5 domain routers.
 // A single requireAuth() gate wraps all AI sub-routers so the route snapshot

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -22,6 +22,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { Hono } from "hono";
 import { logger } from "hono/logger";
+import { bridgeForwardauthSession } from "./auth/forwardauth-bridge.js";
 import { requireAuth } from "./auth/middleware.js";
 import { config } from "./config.js";
 import { securityHeaders } from "./middleware/security-headers.js";
@@ -55,6 +56,11 @@ app.use("*", logger());
 // and static-file responses carry the headers. HSTS is harmless on HTTP
 // (ignored by browsers) and covers the production TLS deployment.
 app.use("*", securityHeaders());
+// SSO session bridge — fires on every request, mints an ap_session cookie for
+// forwardauth-identified requests so /auth/me and WS resolve SSO identity via
+// the cookie step (Phase 4 / Decision 2). Must be BEFORE api.route() and the
+// SPA catch-all so the Set-Cookie rides the document response (M-1).
+app.use("*", bridgeForwardauthSession());
 
 // API routes
 const api = new Hono();

--- a/src/server/auth/forwardauth-bridge.test.ts
+++ b/src/server/auth/forwardauth-bridge.test.ts
@@ -1,0 +1,554 @@
+/**
+ * Tests for forwardauth-bridge.ts (Phase 4).
+ *
+ * AC coverage:
+ *  AC 2   — Valid headers + verify → exactly one Set-Cookie; attributes correct.
+ *  AC 3   — End-to-end: mint → /auth/me with cookie → SSO identity.
+ *  AC 5   — Missing verify, wrong verify → no Set-Cookie.
+ *  AC 6a  — Cookie subject mismatch → re-mint.
+ *  AC 6b  — Fail-closed: issueSession throws → cookie cleared; /auth/me unauthenticated.
+ *  AC 8   — WS cookie-only: resolveSessionByToken resolves SSO identity without forwardauth headers.
+ *  AC 9   — DISABLE_AUTH=true → no mint.
+ *  AC 10  — Local-auth regression: /auth/login + /auth/me with local cookie.
+ *  M-1    — Set-Cookie appears on a "/" request (bridge fires before SPA catch-all);
+ *           mint failure with existing cookie → DB row revoked server-side.
+ *  M-4    — Provider mismatch → re-mint.
+ *  M-8    — Valid local ap_session + forwardauth headers → SSO minted, old local row revoked.
+ *  L-2    — SSO cookie for different subject + forwardauth headers → re-mint, old SSO row revoked.
+ *  L-4    — Oversized subject (> 512 chars) → no mint.
+ *
+ * No module-level mocks. verifyForwardauthSecret, verifyApiKey, and issueSession are
+ * NOT mocked (exception: the fail-closed AC 6b test uses DI on bridgeForwardauthSession
+ * to inject a throwing issueSession — dependency injection, not module mocking).
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import "../db/__test_db.js";
+
+const { config } = await import("../config.js");
+const { initializeDatabase } = await import("../db/client.js");
+import type { IssueSessionFn } from "./forwardauth-bridge.js";
+
+const { bridgeForwardauthSession } = await import("./forwardauth-bridge.js");
+const {
+	SESSION_COOKIE_NAME,
+	SSO_SESSION_DURATION_MS,
+	createUser,
+	issueSession,
+	resolveSessionByToken,
+} = await import("../services/local-auth-service.js");
+const { Hono } = await import("hono");
+const { authRouter } = await import("../routes/auth.js");
+
+// ─── Test configuration ──────────────────────────────────────────────────────
+
+const TEST_SECRET = "bridge-test-secret-32-chars-long!";
+const TEST_SUBJECT = "user-abc-123";
+const TEST_USERNAME = "alice";
+const TEST_PROVIDER = "authentik";
+
+/** Build request headers that look like a valid Traefik forwardauth pass-through. */
+function forwardauthHeaders(overrides: Record<string, string> = {}): Headers {
+	const h = new Headers({
+		"X-Authentik-Username": TEST_USERNAME,
+		"X-Authentik-Uid": TEST_SUBJECT,
+		"X-Authentik-Verify": TEST_SECRET,
+		...overrides,
+	});
+	return h;
+}
+
+/** Build a minimal test app with bridge + auth router (no full app import). */
+function makeBridgeApp(bridgeOpts: { issueSession?: IssueSessionFn } = {}) {
+	const testApp = new Hono();
+	testApp.use("*", bridgeForwardauthSession(bridgeOpts));
+	testApp.route("/api/v1", authRouter);
+	return testApp;
+}
+
+// ─── Setup / teardown ────────────────────────────────────────────────────────
+
+const originalDisableAuth = config.disableAuth;
+const originalSecret = process.env.FORWARDAUTH_TRUST_SECRET;
+const originalProvider = process.env.FORWARDAUTH_PROVIDER;
+
+beforeAll(async () => {
+	await initializeDatabase();
+	process.env.FORWARDAUTH_TRUST_SECRET = TEST_SECRET;
+	process.env.FORWARDAUTH_PROVIDER = TEST_PROVIDER;
+	(config as Record<string, unknown>).disableAuth = false;
+});
+
+afterAll(() => {
+	(config as Record<string, unknown>).disableAuth = originalDisableAuth;
+	if (originalSecret === undefined) {
+		process.env.FORWARDAUTH_TRUST_SECRET = undefined;
+	} else {
+		process.env.FORWARDAUTH_TRUST_SECRET = originalSecret;
+	}
+	if (originalProvider === undefined) {
+		process.env.FORWARDAUTH_PROVIDER = undefined;
+	} else {
+		process.env.FORWARDAUTH_PROVIDER = originalProvider;
+	}
+});
+
+// ─── Parse Set-Cookie helper ─────────────────────────────────────────────────
+
+interface ParsedSetCookie {
+	name: string;
+	value: string;
+	httpOnly: boolean;
+	secure: boolean;
+	sameSite: string | null;
+	path: string | null;
+	maxAge: number | null;
+}
+
+function parseSetCookie(header: string): ParsedSetCookie {
+	const parts = header.split(";").map((p) => p.trim());
+	const [nameValue, ...attrs] = parts;
+	const eqIdx = nameValue?.indexOf("=");
+	const name = nameValue?.slice(0, eqIdx);
+	const value = nameValue?.slice(eqIdx + 1);
+	let httpOnly = false;
+	let secure = false;
+	let sameSite: string | null = null;
+	let path: string | null = null;
+	let maxAge: number | null = null;
+	for (const attr of attrs) {
+		const lower = attr.toLowerCase();
+		if (lower === "httponly") httpOnly = true;
+		else if (lower === "secure") secure = true;
+		else if (lower.startsWith("samesite=")) sameSite = attr.slice("SameSite=".length);
+		else if (lower.startsWith("path=")) path = attr.slice("Path=".length);
+		else if (lower.startsWith("max-age=")) maxAge = Number(attr.slice("Max-Age=".length));
+	}
+	return { name, value, httpOnly, secure, sameSite, path, maxAge };
+}
+
+/** Extract the ap_session Set-Cookie header from a response (null if absent). */
+function getSessionSetCookie(res: Response): ParsedSetCookie | null {
+	const setCookieHeaders: string[] = [];
+	res.headers.forEach((value, key) => {
+		if (key.toLowerCase() === "set-cookie") {
+			setCookieHeaders.push(value);
+		}
+	});
+	const sessionCookie = setCookieHeaders.find((h) => h.startsWith(`${SESSION_COOKIE_NAME}=`));
+	return sessionCookie ? parseSetCookie(sessionCookie) : null;
+}
+
+/** Count how many Set-Cookie headers match ap_session. */
+function countSessionSetCookies(res: Response): number {
+	let count = 0;
+	res.headers.forEach((value, key) => {
+		if (key.toLowerCase() === "set-cookie" && value.startsWith(`${SESSION_COOKIE_NAME}=`)) {
+			count++;
+		}
+	});
+	return count;
+}
+
+// ─── AC 2: Valid headers + verify → one Set-Cookie with correct attributes ───
+
+describe("AC 2 — valid forwardauth headers → exactly one Set-Cookie with correct attributes", () => {
+	test("Set-Cookie is present and has expected count = 1", async () => {
+		const testApp = makeBridgeApp();
+		const res = await testApp.request("/api/v1/auth/me", { headers: forwardauthHeaders() });
+		expect(countSessionSetCookies(res)).toBe(1);
+	});
+
+	test("Set-Cookie attributes: HttpOnly, SameSite=Lax, Path=/, Max-Age=SSO_SESSION_DURATION_MS/1000", async () => {
+		const testApp = makeBridgeApp();
+		const res = await testApp.request("/api/v1/auth/me", { headers: forwardauthHeaders() });
+		const cookie = getSessionSetCookie(res);
+		expect(cookie).not.toBeNull();
+		expect(cookie?.name).toBe(SESSION_COOKIE_NAME);
+		expect(cookie?.httpOnly).toBe(true);
+		// Secure=false in test mode (isProduction is false). Assert the attr matches.
+		expect(cookie?.secure).toBe(config.isProduction);
+		expect(cookie?.sameSite).toBe("Lax");
+		expect(cookie?.path).toBe("/");
+		expect(cookie?.maxAge).toBe(Math.floor(SSO_SESSION_DURATION_MS / 1000));
+	});
+
+	test("M-1 — Set-Cookie appears on GET / (bridge fires before SPA catch-all)", async () => {
+		const testApp = makeBridgeApp();
+		const res = await testApp.request("/", { headers: forwardauthHeaders() });
+		// Response may be 404 in test mode (no SPA), but the bridge should still set the cookie.
+		expect(countSessionSetCookies(res)).toBe(1);
+	});
+});
+
+// ─── Idempotent mint ─────────────────────────────────────────────────────────
+
+describe("idempotent mint — same subject+provider cookie → no re-mint", () => {
+	test("second request with the minted cookie does not set a new cookie", async () => {
+		const testApp = makeBridgeApp();
+		// First request — mints a cookie.
+		const res1 = await testApp.request("/api/v1/auth/me", { headers: forwardauthHeaders() });
+		const first = getSessionSetCookie(res1);
+		expect(first).not.toBeNull();
+
+		// Second request — same subject, attach the minted cookie.
+		const headers2 = forwardauthHeaders({ Cookie: `${SESSION_COOKIE_NAME}=${first?.value}` });
+		const res2 = await testApp.request("/api/v1/auth/me", { headers: headers2 });
+		// No re-mint expected.
+		expect(countSessionSetCookies(res2)).toBe(0);
+	});
+});
+
+// ─── AC 5: Trust-gate reject ─────────────────────────────────────────────────
+
+describe("AC 5 — trust-gate reject → no Set-Cookie", () => {
+	test("missing verify header → no Set-Cookie", async () => {
+		const testApp = makeBridgeApp();
+		const h = new Headers({
+			"X-Authentik-Username": TEST_USERNAME,
+			"X-Authentik-Uid": TEST_SUBJECT,
+			// no X-Authentik-Verify
+		});
+		const res = await testApp.request("/api/v1/auth/me", { headers: h });
+		expect(countSessionSetCookies(res)).toBe(0);
+	});
+
+	test("wrong verify value → no Set-Cookie", async () => {
+		const testApp = makeBridgeApp();
+		const h = forwardauthHeaders({ "X-Authentik-Verify": "wrong-secret" });
+		const res = await testApp.request("/api/v1/auth/me", { headers: h });
+		expect(countSessionSetCookies(res)).toBe(0);
+	});
+});
+
+// ─── AC 6a: Cookie subject mismatch → re-mint ────────────────────────────────
+
+describe("AC 6a — cookie subject mismatch → re-mint (new Set-Cookie)", () => {
+	test("different-subject SSO cookie + forwardauth headers for new subject → re-mint", async () => {
+		// Issue an SSO session for a different subject.
+		const { token: oldToken } = await issueSession({
+			userId: "sso:other-subject",
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: "other-subject",
+			ssoUsername: "other-user",
+			provider: TEST_PROVIDER,
+		});
+
+		const testApp = makeBridgeApp();
+		const h = forwardauthHeaders({ Cookie: `${SESSION_COOKIE_NAME}=${oldToken}` });
+		const res = await testApp.request("/api/v1/auth/me", { headers: h });
+		const cookie = getSessionSetCookie(res);
+		// A new cookie must be minted (not the same token).
+		expect(cookie).not.toBeNull();
+		expect(cookie?.value).not.toBe(oldToken);
+	});
+});
+
+// ─── M-4: Provider mismatch → re-mint ───────────────────────────────────────
+
+describe("M-4 — provider mismatch → re-mint", () => {
+	test("SSO cookie for different provider + forwardauth headers → re-mint", async () => {
+		// Issue a session for the same subject but a different provider.
+		const { token: oldToken } = await issueSession({
+			userId: `sso:${TEST_SUBJECT}`,
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: TEST_SUBJECT,
+			ssoUsername: TEST_USERNAME,
+			provider: "other-provider",
+		});
+
+		const testApp = makeBridgeApp();
+		const h = forwardauthHeaders({ Cookie: `${SESSION_COOKIE_NAME}=${oldToken}` });
+		const res = await testApp.request("/api/v1/auth/me", { headers: h });
+		const cookie = getSessionSetCookie(res);
+		expect(cookie).not.toBeNull();
+		expect(cookie?.value).not.toBe(oldToken);
+	});
+});
+
+// ─── AC 6b: Fail-closed ──────────────────────────────────────────────────────
+
+describe("AC 6b — fail-closed (issueSession throws)", () => {
+	const failingIssueSession: IssueSessionFn = async () => {
+		throw new Error("simulated DB failure");
+	};
+
+	test("(i) valid local cookie present + mint throws → response clears the cookie (Max-Age=0)", async () => {
+		// Issue a real local session.
+		const user = await createUser({
+			username: `fc-local-${Date.now()}`,
+			password: "TestPass123!",
+			role: "user",
+		});
+		const { token: localToken } = await issueSession({ userId: user.id });
+
+		const testApp = makeBridgeApp({ issueSession: failingIssueSession });
+		const h = forwardauthHeaders({ Cookie: `${SESSION_COOKIE_NAME}=${localToken}` });
+		const res = await testApp.request("/api/v1/auth/me", { headers: h });
+
+		// Must clear the cookie (Max-Age=0 is the standard deletion mechanism).
+		const deleteCookieHeader = [...res.headers.entries()].find(
+			([k, v]) => k.toLowerCase() === "set-cookie" && v.includes(`${SESSION_COOKIE_NAME}=`),
+		)?.[1];
+		expect(deleteCookieHeader).toBeDefined();
+		if (!deleteCookieHeader) throw new Error("expected Set-Cookie header");
+		const parsed = parseSetCookie(deleteCookieHeader);
+		expect(parsed.maxAge).toBe(0);
+	});
+
+	test("(i) subsequent /auth/me with local token does NOT authenticate planted identity", async () => {
+		// After a failed mint with local cookie, the local session itself is still valid.
+		// The key assertion: no new SSO cookie was minted, and the planted SSO cookie
+		// would have been cleared. Test by using no cookie at all on /auth/me.
+		const testApp2 = makeBridgeApp();
+		// /auth/me with no cookie, no forwardauth headers → unauthenticated.
+		const res = await testApp2.request("/api/v1/auth/me");
+		const body = (await res.json()) as { authenticated: boolean };
+		expect(body.authenticated).toBe(false);
+	});
+
+	test("(ii) different-subject SSO cookie present + mint throws → response clears the cookie", async () => {
+		const { token: ssoToken } = await issueSession({
+			userId: "sso:evil-subject",
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: "evil-subject",
+			ssoUsername: "evil-user",
+			provider: TEST_PROVIDER,
+		});
+
+		const testApp = makeBridgeApp({ issueSession: failingIssueSession });
+		const h = forwardauthHeaders({ Cookie: `${SESSION_COOKIE_NAME}=${ssoToken}` });
+		const res = await testApp.request("/api/v1/auth/me", { headers: h });
+
+		const deleteCookieHeader = [...res.headers.entries()].find(
+			([k, v]) => k.toLowerCase() === "set-cookie" && v.includes(`${SESSION_COOKIE_NAME}=`),
+		)?.[1];
+		expect(deleteCookieHeader).toBeDefined();
+		if (!deleteCookieHeader) throw new Error("expected Set-Cookie header");
+		const parsed = parseSetCookie(deleteCookieHeader);
+		expect(parsed.maxAge).toBe(0);
+	});
+
+	test("no cookie present + mint throws → no Set-Cookie header at all", async () => {
+		const testApp = makeBridgeApp({ issueSession: failingIssueSession });
+		const res = await testApp.request("/api/v1/auth/me", { headers: forwardauthHeaders() });
+		// No cookie was present to clear; no Set-Cookie at all.
+		expect(countSessionSetCookies(res)).toBe(0);
+	});
+});
+
+// ─── AC 3: End-to-end mint → /auth/me ────────────────────────────────────────
+
+describe("AC 3 — end-to-end: mint via bridge, then /auth/me with cookie → SSO identity", () => {
+	test("GET /api/v1/auth/me with minted cookie → authenticated:true, source:forwardauth", async () => {
+		const testApp = makeBridgeApp();
+
+		// Step 1: trigger bridge to mint a cookie.
+		const mintRes = await testApp.request("/api/v1/auth/me", { headers: forwardauthHeaders() });
+		const mintedCookie = getSessionSetCookie(mintRes);
+		expect(mintedCookie).not.toBeNull();
+
+		// Step 2: request /auth/me with only the minted cookie (no forwardauth headers).
+		const res = await testApp.request("/api/v1/auth/me", {
+			headers: new Headers({ Cookie: `${SESSION_COOKIE_NAME}=${mintedCookie?.value}` }),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			authenticated: boolean;
+			user: { source: string; provider: string; id: string; name: string };
+			signOutUrl: string | null;
+		};
+		expect(body.authenticated).toBe(true);
+		expect(body.user.source).toBe("forwardauth");
+		expect(body.user.provider).toBe("authentik");
+		expect(body.user.id).toBe(TEST_SUBJECT);
+		expect(body.user.name).toBe(TEST_USERNAME);
+		expect(body.signOutUrl).toBe("/outpost.goauthentik.io/sign_out");
+	});
+});
+
+// ─── M-1: Fail-closed DB revocation ─────────────────────────────────────────
+
+describe("M-1 — mint failure with existing cookie → DB row revoked AND browser cookie cleared", () => {
+	const failingIssueSession: IssueSessionFn = async () => {
+		throw new Error("simulated DB failure");
+	};
+
+	test("local session row resolves to null after failed mint (server-side revoke)", async () => {
+		const user = await createUser({
+			username: `m1-db-${Date.now()}`,
+			password: "TestPass123!",
+			role: "user",
+		});
+		const { token: localToken } = await issueSession({ userId: user.id });
+
+		// Sanity: local session is valid before the bridge fires.
+		const before = await resolveSessionByToken(localToken);
+		expect(before?.kind).toBe("local");
+
+		const testApp = makeBridgeApp({ issueSession: failingIssueSession });
+		const h = forwardauthHeaders({ Cookie: `${SESSION_COOKIE_NAME}=${localToken}` });
+		await testApp.request("/api/v1/auth/me", { headers: h });
+
+		// After a failed mint, the DB row must have been revoked server-side.
+		const after = await resolveSessionByToken(localToken);
+		expect(after).toBeNull();
+	});
+});
+
+// ─── L-2: SSO-to-SSO supersession ────────────────────────────────────────────
+
+describe("L-2 — SSO cookie for different subject → re-mint AND old SSO row revoked", () => {
+	test("old SSO token resolves to null after new SSO mint for a different subject", async () => {
+		// Issue an SSO session for subject B.
+		const { token: subjectBToken } = await issueSession({
+			userId: "sso:subject-b-l2",
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: "subject-b-l2",
+			ssoUsername: "user-b",
+			provider: TEST_PROVIDER,
+		});
+
+		// Sanity: subject B's session is valid.
+		const before = await resolveSessionByToken(subjectBToken);
+		expect(before?.kind).toBe("sso");
+
+		// Now the bridge fires for subject A (TEST_SUBJECT) with subject B's cookie.
+		const testApp = makeBridgeApp();
+		const h = forwardauthHeaders({ Cookie: `${SESSION_COOKIE_NAME}=${subjectBToken}` });
+		const res = await testApp.request("/api/v1/auth/me", { headers: h });
+
+		// A new SSO cookie must be minted for subject A.
+		const newCookie = getSessionSetCookie(res);
+		expect(newCookie).not.toBeNull();
+		expect(newCookie?.value).not.toBe(subjectBToken);
+
+		// Subject B's DB row must be revoked.
+		const after = await resolveSessionByToken(subjectBToken);
+		expect(after).toBeNull();
+	});
+});
+
+// ─── L-4: Subject length guard ───────────────────────────────────────────────
+
+describe("L-4 — oversized subject (> 512 chars) → no mint, no Set-Cookie", () => {
+	test("513-char subject → no Set-Cookie", async () => {
+		const longSubject = "x".repeat(513);
+		const testApp = makeBridgeApp();
+		const h = forwardauthHeaders({ "X-Authentik-Uid": longSubject });
+		const res = await testApp.request("/api/v1/auth/me", { headers: h });
+		expect(countSessionSetCookies(res)).toBe(0);
+	});
+
+	test("512-char subject → mint succeeds (at boundary)", async () => {
+		const boundarySubject = "y".repeat(512);
+		const testApp = makeBridgeApp();
+		const h = forwardauthHeaders({ "X-Authentik-Uid": boundarySubject });
+		const res = await testApp.request("/api/v1/auth/me", { headers: h });
+		expect(countSessionSetCookies(res)).toBe(1);
+	});
+});
+
+// ─── M-8: Local-collision — local session superseded ─────────────────────────
+
+describe("M-8 — valid local ap_session + forwardauth headers → SSO minted, old local row revoked", () => {
+	test("old local token resolves to null after SSO mint completes", async () => {
+		const user = await createUser({
+			username: `m8-${Date.now()}`,
+			password: "TestPass123!",
+			role: "user",
+		});
+		const { token: localToken } = await issueSession({ userId: user.id });
+
+		// Sanity: local session is valid before the bridge fires.
+		const before = await resolveSessionByToken(localToken);
+		expect(before?.kind).toBe("local");
+
+		const testApp = makeBridgeApp();
+		const h = forwardauthHeaders({ Cookie: `${SESSION_COOKIE_NAME}=${localToken}` });
+		await testApp.request("/api/v1/auth/me", { headers: h });
+
+		// After the bridge mints an SSO session, the old local session must be revoked.
+		const after = await resolveSessionByToken(localToken);
+		expect(after).toBeNull();
+	});
+});
+
+// ─── AC 8: WS/cookie-only SSO resolution ─────────────────────────────────────
+
+describe("AC 8 — cookie-only SSO resolution (no forwardauth headers)", () => {
+	test("resolveSessionByToken on an SSO session row → kind:sso with correct fields", async () => {
+		const { token } = await issueSession({
+			userId: `sso:${TEST_SUBJECT}-ws`,
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: `${TEST_SUBJECT}-ws`,
+			ssoUsername: TEST_USERNAME,
+			provider: TEST_PROVIDER,
+		});
+		// This is the path that getAuthUserFromHeaders step-3 takes for WS requests
+		// that carry the cookie but no forwardauth headers (WS upgrade bypasses Traefik
+		// forwardauth — the cookie is the only credential).
+		const resolved = await resolveSessionByToken(token);
+		expect(resolved?.kind).toBe("sso");
+		if (resolved?.kind === "sso") {
+			expect(resolved.subject).toBe(`${TEST_SUBJECT}-ws`);
+			expect(resolved.username).toBe(TEST_USERNAME);
+			expect(resolved.provider).toBe(TEST_PROVIDER);
+		}
+	});
+});
+
+// ─── AC 9 / DISABLE_AUTH ────────────────────────────────────────────────────
+
+describe("AC 9 — DISABLE_AUTH=true → no mint", () => {
+	test("no Set-Cookie when disableAuth is true", async () => {
+		(config as Record<string, unknown>).disableAuth = true;
+		try {
+			const testApp = makeBridgeApp();
+			const res = await testApp.request("/api/v1/auth/me", { headers: forwardauthHeaders() });
+			expect(countSessionSetCookies(res)).toBe(0);
+		} finally {
+			(config as Record<string, unknown>).disableAuth = false;
+		}
+	});
+});
+
+// ─── AC 10: Local-auth regression ────────────────────────────────────────────
+
+describe("AC 10 — local-auth regression: login + /auth/me with local cookie", () => {
+	test("POST /auth/login issues a local session; /auth/me with it → source:local", async () => {
+		const testApp = makeBridgeApp();
+
+		// Create a user first.
+		const username = `local-${Date.now()}`;
+		await createUser({ username, password: "TestPass123!", role: "user" });
+
+		// Login.
+		const loginRes = await testApp.request("/api/v1/auth/login", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ username, password: "TestPass123!" }),
+		});
+		expect(loginRes.status).toBe(200);
+
+		// Extract the session cookie from the login response.
+		const loginCookie = getSessionSetCookie(loginRes);
+		expect(loginCookie).not.toBeNull();
+
+		// GET /auth/me with ONLY the local cookie (no forwardauth headers).
+		const meRes = await testApp.request("/api/v1/auth/me", {
+			headers: new Headers({ Cookie: `${SESSION_COOKIE_NAME}=${loginCookie?.value}` }),
+		});
+		expect(meRes.status).toBe(200);
+		const body = (await meRes.json()) as {
+			authenticated: boolean;
+			user: { source: string };
+		};
+		expect(body.authenticated).toBe(true);
+		expect(body.user.source).toBe("local");
+	});
+});

--- a/src/server/auth/forwardauth-bridge.ts
+++ b/src/server/auth/forwardauth-bridge.ts
@@ -1,0 +1,170 @@
+/**
+ * forwardauth-bridge.ts — Hono middleware that converts a live forwardauth
+ * identity header set into a short-lived `ap_session` cookie so subsequent
+ * un-forwardauth'd requests (e.g. `/auth/me`, WS upgrade) resolve the SSO
+ * identity through the existing cookie step of `getAuthUserFromHeaders`.
+ *
+ * Security properties:
+ *  - Verifies the trust secret BEFORE reading any identity header (H-1).
+ *  - Resolve-then-mint: skips the mint when the existing cookie already matches
+ *    the current subject+provider (Decision 3, fixation-safe). Otherwise always
+ *    mints fresh, preventing session fixation via a planted cookie.
+ *  - Fail closed: on mint failure, revokes the DB row (if any) AND clears the
+ *    browser cookie, keyed on the raw cookie string being non-null — an expired
+ *    or foreign token still gets cleaned up server-side (xander / M-1 / H-1).
+ *  - M-8 / L-2 supersession: when any resolved session is superseded by a new
+ *    SSO mint (local OR SSO-mismatch), the old DB row is revoked after a
+ *    successful mint so it isn't orphaned.
+ *  - L-4 subject guard: subjects longer than 512 chars are rejected (no mint).
+ *
+ * Mount point: `app.use("*", bridgeForwardauthSession())` in app.ts immediately
+ * after `securityHeaders()` and before any api.route(...) or the SPA catch-all
+ * (Decision 2 / M-1). This ensures Set-Cookie rides the SPA document response.
+ */
+import type { Context, Next } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { config } from "../config.js";
+import { cookieOptions } from "../routes/auth.js";
+import {
+	SESSION_COOKIE_NAME,
+	SSO_SESSION_DURATION_MS,
+	issueSession,
+	resolveSessionByToken,
+	revokeSessionByToken,
+} from "../services/local-auth-service.js";
+import { verifyForwardauthSecret } from "./middleware.js";
+
+/** Cookie options for SSO sessions (8h TTL by default; env-tunable). Internal use only. */
+function ssoCookieOptions() {
+	return cookieOptions(SSO_SESSION_DURATION_MS);
+}
+
+export type IssueSessionFn = typeof issueSession;
+
+/**
+ * Hono middleware factory. Accepts an optional `deps` object for test-only
+ * dependency injection (e.g. a failing `issueSession` to exercise fail-closed).
+ * Production code always calls the real `issueSession`.
+ */
+export function bridgeForwardauthSession(deps: { issueSession?: IssueSessionFn } = {}) {
+	const _issueSession = deps.issueSession ?? issueSession;
+
+	return async function bridge(c: Context, next: Next) {
+		// 1. Skip when auth is disabled (DISABLE_AUTH=true).
+		if (config.disableAuth) {
+			return next();
+		}
+
+		// 2. Skip when the request didn't traverse forwardauth (no username header).
+		//    This covers /auth/me, /auth/login, Bearer API calls — they reach the
+		//    app WITHOUT going through the forwardauth upstream, so there are no
+		//    identity headers.
+		const forwardauthUser = c.req.raw.headers.get(config.forwardauthHeader("username"));
+		if (!forwardauthUser) {
+			return next();
+		}
+
+		// 3. Verify trust secret BEFORE trusting any identity header. The bridge
+		//    must verify first (H-1) — forged headers can be injected otherwise.
+		const verifyValue = c.req.raw.headers.get(config.forwardauthHeader("verify")) ?? "";
+		if (!verifyForwardauthSecret(verifyValue)) {
+			// Invalid verify — do NOT mint. The resolver's existing strip/reject
+			// logic (in getAuthUserFromHeaders) applies to the current request;
+			// this middleware's job is minting for future un-forwardauth'd requests.
+			return next();
+		}
+
+		// 4. Resolve subject and display username.
+		//    uid is stable across renames (Decision 4 open Q2); fall back to username.
+		const subject = c.req.raw.headers.get(config.forwardauthHeader("uid")) || forwardauthUser;
+		const username = forwardauthUser;
+		const provider = config.forwardauthProvider;
+
+		// L-4: Defensive guard — reject abnormally long subjects before touching the DB.
+		if (subject.length > 512) {
+			console.warn(
+				JSON.stringify({
+					kind: "forwardauth_bridge_subject_too_long",
+					level: "warn",
+					length: subject.length,
+				}),
+			);
+			return next();
+		}
+
+		// 5. Resolve-then-mint (Decision 3).
+		//    Read the raw ap_session cookie string — its PRESENCE (not resolve result)
+		//    is what governs fail-closed deletion on mint failure (xander / H-1).
+		const rawCookieToken = getCookie(c, SESSION_COOKIE_NAME) ?? null;
+
+		let resolved: Awaited<ReturnType<typeof resolveSessionByToken>> | undefined;
+		if (rawCookieToken) {
+			resolved = await resolveSessionByToken(rawCookieToken);
+		}
+
+		// Skip mint iff the cookie already holds an SSO session for this exact
+		// subject+provider. All other cases (no cookie, expired, different
+		// subject, different provider, local session) fall through to mint.
+		if (
+			resolved?.kind === "sso" &&
+			resolved.provider === provider &&
+			resolved.subject === subject
+		) {
+			return next();
+		}
+
+		// M-8 / L-2: track any resolved session that will be superseded so it
+		// can be revoked after a successful mint. `resolved` is non-null only when
+		// a real DB row exists — covers both local sessions (M-8) and SSO sessions
+		// for a different subject or provider (L-2). Never revoke before mint.
+		const oldSupersededToken = resolved != null ? rawCookieToken : null;
+
+		// 6. Mint — wrapped in try/catch for fail-closed behaviour (H-1 / M-1).
+		let mintedToken: string | null = null;
+		try {
+			const { token } = await _issueSession({
+				userId: `sso:${subject}`,
+				durationMs: SSO_SESSION_DURATION_MS,
+				authSource: "forwardauth",
+				ssoSubject: subject,
+				ssoUsername: username,
+				provider,
+				userAgent: c.req.header("User-Agent") ?? null,
+			});
+			mintedToken = token;
+		} catch (err) {
+			// H-1 / M-1 fail-closed: log the failure; if a raw cookie string was
+			// present in the request, revoke its DB row (server-side) then clear the
+			// browser cookie so a stale/hostile token can't survive in either place.
+			// Key on the raw string being non-null, NOT on the resolve result —
+			// an expired/foreign token resolves to null yet must still be cleaned up.
+			console.warn(
+				JSON.stringify({
+					kind: "forwardauth_bridge_mint_failed",
+					level: "warn",
+					error: String(err),
+				}),
+			);
+			if (rawCookieToken !== null) {
+				await revokeSessionByToken(rawCookieToken).catch(() => {});
+				deleteCookie(c, SESSION_COOKIE_NAME, { path: "/" });
+			}
+			// Current request still resolves inline via step-1 forwardauth headers
+			// in getAuthUserFromHeaders — the page loads as the correct user.
+			return next();
+		}
+
+		// 6 (continued). Set-Cookie BEFORE next() so it rides the SPA document
+		// response (or whatever this request is responding with).
+		setCookie(c, SESSION_COOKIE_NAME, mintedToken, ssoCookieOptions());
+
+		await next();
+
+		// 7. M-8 / L-2 supersession: revoke the old session AFTER a successful
+		// mint+next so it isn't orphaned. Errors here are swallowed — the new SSO
+		// session is already issued; a revocation failure is cosmetic.
+		if (oldSupersededToken) {
+			await revokeSessionByToken(oldSupersededToken).catch(() => {});
+		}
+	};
+}

--- a/src/server/auth/forwardauth-bridge.ts
+++ b/src/server/auth/forwardauth-bridge.ts
@@ -5,7 +5,10 @@
  * identity through the existing cookie step of `getAuthUserFromHeaders`.
  *
  * Security properties:
- *  - Verifies the trust secret BEFORE reading any identity header (H-1).
+ *  - Verifies the trust secret before trusting or acting on any identity
+ *    header value (H-1). The username header is read first as an early-exit
+ *    signal (non-forwardauth request → skip), but no identity value is trusted
+ *    or written until after secret verification passes.
  *  - Resolve-then-mint: skips the mint when the existing cookie already matches
  *    the current subject+provider (Decision 3, fixation-safe). Otherwise always
  *    mints fresh, preventing session fixation via a planted cookie.

--- a/src/server/auth/middleware.test.ts
+++ b/src/server/auth/middleware.test.ts
@@ -14,7 +14,7 @@
  * module that opens the DB doesn't collide with the main test suite.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
 // Set SQLITE_PATH before any other import opens the DB.
 import "../db/__test_db.ts";
@@ -366,6 +366,57 @@ describe("config deprecation warning", () => {
 		const shouldWarn =
 			!!process.env.AGENTPULSE_AUTHENTIK_TRUST_SECRET && !process.env.FORWARDAUTH_TRUST_SECRET;
 		expect(shouldWarn).toBe(false);
+	});
+});
+
+// ── Bearer ap_* precedence — real Headers (ian Low, Decision 8 / C-1 residual) ─
+//
+// The duck-typed {get} wrapper in local-auth-service.test.ts skips the
+// `headers instanceof Headers` trust-gate branch. These tests drive
+// getAuthUserFromHeaders with a real `Headers` instance (the production path)
+// to confirm the Bearer-precedence fix works end-to-end in the same code path
+// that live HTTP requests exercise. DB is required (verifyApiKey is NOT mocked).
+
+describe("Bearer ap_* precedence — real Headers (Decision 8)", () => {
+	// One-time DB init for this describe block. initializeDatabase is idempotent.
+	beforeAll(async () => {
+		const { initializeDatabase } = await import("../db/client.js");
+		await initializeDatabase();
+	});
+
+	test("real Headers: valid ap_session cookie + Authorization: Bearer ap_<invalid> → null (cookie NOT consulted)", async () => {
+		// Create a real local session so the cookie *would* resolve if consulted.
+		// This proves the test is meaningful: if the Bearer check were absent or
+		// fell through, the cookie would yield {source:"local",...}, not null.
+		const { createUser, issueSession } = await import("../services/local-auth-service.js");
+		const user = await createUser({ username: "mwbearer1", password: "S3cur3P@ssword!" });
+		const { token: cookieToken } = await issueSession({ userId: user.id });
+
+		const h = new Headers();
+		h.set("Cookie", `ap_session=${cookieToken}`);
+		h.set("Authorization", "Bearer ap_invalidkeyvalue0000000000000"); // syntactic but unknown
+
+		const result = await getAuthUserFromHeaders(h);
+		// The invalid Bearer must short-circuit BEFORE the cookie is consulted.
+		// Expected: null (not {source:"local",...}).
+		expect(result).toBeNull();
+	});
+
+	test("real Headers: valid ap_session cookie + valid Bearer ap_<realkey> → source:'api_key' (Q4 KEEP)", async () => {
+		// Confirm that a genuine API key authorizes correctly via the new step.
+		const { createApiKey } = await import("./api-key.js");
+		const { createUser, issueSession } = await import("../services/local-auth-service.js");
+
+		const user = await createUser({ username: "mwbearer2", password: "S3cur3P@ssword!" });
+		const { token: cookieToken } = await issueSession({ userId: user.id });
+		const { key: realKey } = await createApiKey("mw-bearer-test-key");
+
+		const h = new Headers();
+		h.set("Cookie", `ap_session=${cookieToken}`);
+		h.set("Authorization", `Bearer ${realKey}`);
+
+		const result = await getAuthUserFromHeaders(h);
+		expect(result?.source).toBe("api_key");
 	});
 });
 

--- a/src/server/auth/middleware.ts
+++ b/src/server/auth/middleware.ts
@@ -40,7 +40,7 @@ function stripForwardauthHeaders(rawHeaders: Headers): void {
 // Returns true only when the secret is configured AND matches the header value.
 // On any failure (missing secret, missing header, length mismatch, wrong value)
 // returns false — caller is responsible for stripping headers and returning null.
-function verifyForwardauthSecret(provided: string): boolean {
+export function verifyForwardauthSecret(provided: string): boolean {
 	const expected = config.forwardauthTrustSecret;
 	if (!expected || !provided) return false;
 
@@ -53,9 +53,7 @@ function verifyForwardauthSecret(provided: string): boolean {
 	return timingSafeEqual(expectedBuf, providedBuf);
 }
 
-export async function getAuthUserFromHeaders(
-	headers: Headers | { get(name: string): string | null },
-): Promise<AuthUser | null> {
+export async function getAuthUserFromHeaders(headers: Headers): Promise<AuthUser | null> {
 	if (config.disableAuth) {
 		return { source: "api_key", name: "anonymous", id: "anonymous" };
 	}
@@ -63,36 +61,20 @@ export async function getAuthUserFromHeaders(
 	// 1. Forwardauth identity headers — validated via shared-secret trust gate.
 	//    Header names are configurable; defaults are Authentik-compatible (e.g.
 	//    X-Authentik-Username) so any forwardauth IdP works via env config.
-	//    Note: the trust gate is only enforced when called with real Headers
-	//    (i.e. from getAuthUser(c)); duck-typed wrapper callers never carry
-	//    forwardauth headers in practice. Prefer getAuthUser(c) for full enforcement.
 	const forwardauthUser = headers.get(config.forwardauthHeader("username"));
 	if (forwardauthUser) {
-		// If called with real Headers (not the duck-typed wrapper), enforce trust gate.
-		if (headers instanceof Headers) {
-			const provided = headers.get(config.forwardauthHeader("verify")) ?? "";
-			if (!verifyForwardauthSecret(provided)) {
-				stripForwardauthHeaders(headers);
-				console.warn(
-					JSON.stringify({
-						kind: "forwardauth_trust_gate_rejected",
-						level: "warn",
-						reason: provided ? "secret_mismatch" : "missing_verify_header",
-					}),
-				);
-				// Fall through to other auth methods — headers stripped.
-			} else {
-				return {
-					source: "forwardauth",
-					provider: config.forwardauthProvider,
-					name: forwardauthUser,
-					id: headers.get(config.forwardauthHeader("uid")) || undefined,
-				};
-			}
+		const provided = headers.get(config.forwardauthHeader("verify")) ?? "";
+		if (!verifyForwardauthSecret(provided)) {
+			stripForwardauthHeaders(headers);
+			console.warn(
+				JSON.stringify({
+					kind: "forwardauth_trust_gate_rejected",
+					level: "warn",
+					reason: provided ? "secret_mismatch" : "missing_verify_header",
+				}),
+			);
+			// Fall through to other auth methods — headers stripped.
 		} else {
-			// Duck-typed wrapper (test/API-key callers): trust without secret check.
-			// This path is not reachable from live HTTP requests — Bun.serve always
-			// passes real Headers. Forwardauth trust gate does not apply here.
 			return {
 				source: "forwardauth",
 				provider: config.forwardauthProvider,

--- a/src/server/auth/middleware.ts
+++ b/src/server/auth/middleware.ts
@@ -1,7 +1,7 @@
 import { timingSafeEqual } from "node:crypto";
 import type { Context, Next } from "hono";
 import { config } from "../config.js";
-import { SESSION_COOKIE_NAME, getUserBySessionToken } from "../services/local-auth-service.js";
+import { SESSION_COOKIE_NAME, resolveSessionByToken } from "../services/local-auth-service.js";
 import { verifyApiKey } from "./api-key.js";
 import { extractSupervisorToken, verifySupervisorCredential } from "./supervisor-auth.js";
 
@@ -102,31 +102,46 @@ export async function getAuthUserFromHeaders(
 		}
 	}
 
-	// 2. Local session cookie (ap_session).
+	// 2. Bearer ap_* is authoritative — must be checked BEFORE the cookie
+	//    (Decision 8, C-1 residual). The edge IngressRoute routes any request
+	//    with a syntactic `Authorization: Bearer ap_*` header around the
+	//    forwardauth catch-all. Without this guard, a stale/foreign `ap_session`
+	//    cookie would authorize via step-3 below even when the API key is invalid.
+	//    Fix: if the header is present it is the ONLY allowed credential for this
+	//    request. Valid key → api_key identity; invalid/unknown key → reject (null).
+	//    Browsers never send this header, so no legitimate flow is broken.
+	//
+	//    The old general `Bearer ` step (which ran after the cookie) is folded
+	//    here: all valid keys are `ap_`-prefixed (api-key.ts:12,45), so there
+	//    was no reachable case for non-`ap_` Bearers in the old code either.
+	const authHeader = headers.get("Authorization");
+	if (authHeader?.startsWith("Bearer ap_")) {
+		const keyRecord = await verifyApiKey(authHeader.slice(7));
+		return keyRecord ? { source: "api_key", name: keyRecord.name, id: keyRecord.id } : null;
+	}
+
+	// 3. Session cookie (ap_session) — local or SSO-bridged (Phase 2).
+	//    resolveSessionByToken returns a discriminated union so we can map
+	//    local→source:"local" and SSO→source:"forwardauth" here at the boundary,
+	//    keeping the session service free of the AuthUser type (no circular dep).
 	const cookieHeader = headers.get("cookie") ?? headers.get("Cookie");
 	const sessionToken = parseCookieHeader(cookieHeader, SESSION_COOKIE_NAME);
 	if (sessionToken) {
-		const user = await getUserBySessionToken(sessionToken);
-		if (user) {
+		const resolved = await resolveSessionByToken(sessionToken);
+		if (resolved?.kind === "local") {
 			return {
 				source: "local",
-				name: user.username,
-				id: user.id,
-				role: user.role,
+				name: resolved.user.username,
+				id: resolved.user.id,
+				role: resolved.user.role,
 			};
 		}
-	}
-
-	// 3. API key bearer (hook ingest + programmatic clients).
-	const authHeader = headers.get("Authorization");
-	if (authHeader?.startsWith("Bearer ")) {
-		const token = authHeader.slice(7);
-		const keyRecord = await verifyApiKey(token);
-		if (keyRecord) {
+		if (resolved?.kind === "sso") {
 			return {
-				source: "api_key",
-				name: keyRecord.name,
-				id: keyRecord.id,
+				source: "forwardauth",
+				provider: resolved.provider,
+				name: resolved.username,
+				id: resolved.subject,
 			};
 		}
 	}

--- a/src/server/db/client.ts
+++ b/src/server/db/client.ts
@@ -482,7 +482,11 @@ async function runLegacySqliteInit(sqlite: Database): Promise<void> {
 			expires_at TEXT NOT NULL,
 			user_agent TEXT,
 			created_at TEXT NOT NULL DEFAULT (datetime('now')),
-			last_seen_at TEXT NOT NULL DEFAULT (datetime('now'))
+			last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+			auth_source TEXT NOT NULL DEFAULT 'local',
+			sso_subject TEXT,
+			sso_username TEXT,
+			provider TEXT
 		);
 		CREATE INDEX IF NOT EXISTS idx_auth_sessions_user ON auth_sessions(user_id);
 		CREATE INDEX IF NOT EXISTS idx_auth_sessions_expires ON auth_sessions(expires_at);
@@ -1013,6 +1017,13 @@ async function runLegacySqliteInit(sqlite: Database): Promise<void> {
 		// value is left as-is ('archived') because it is still a valid union member for
 		// one release. Idempotent: re-running is a no-op once is_archived=1.
 		"UPDATE sessions SET is_archived = 1 WHERE status = 'archived' AND is_archived = 0",
+		// Phase 1 (SSO bridge): SSO identity columns on auth_sessions.
+		// Idempotent — the migration runner swallows "duplicate column name" errors
+		// (isIdempotentMigrationError) so re-running on an already-migrated DB is safe.
+		"ALTER TABLE auth_sessions ADD COLUMN auth_source TEXT NOT NULL DEFAULT 'local'",
+		"ALTER TABLE auth_sessions ADD COLUMN sso_subject TEXT",
+		"ALTER TABLE auth_sessions ADD COLUMN sso_username TEXT",
+		"ALTER TABLE auth_sessions ADD COLUMN provider TEXT",
 	];
 
 	// Vector search opt-in. The embeddings table only materializes when

--- a/src/server/db/migrations.test.ts
+++ b/src/server/db/migrations.test.ts
@@ -54,6 +54,15 @@ function getTableNames(db: Database): string[] {
 	return rows.map((r) => r.name);
 }
 
+/** Returns the column names for a given table in a SQLite DB. */
+function getColumnNames(db: Database, tableName: string): string[] {
+	const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+	return rows.map((r) => r.name);
+}
+
+/** The 4 SSO identity columns added in Phase 1. */
+const SSO_COLUMNS = ["auth_source", "sso_subject", "sso_username", "provider"] as const;
+
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 describeSqliteOnly("initializeDatabase boot routing — SQLite", () => {
@@ -180,6 +189,16 @@ describeSqliteOnly("initializeDatabase boot routing — SQLite", () => {
 			// event_embeddings is in the SQLite schema (Decision 3).
 			expect(tables).toContain("event_embeddings");
 
+			// Phase 1: all 4 SSO identity columns must be present on auth_sessions
+			// after a fresh Drizzle-SQLite migrate (AC 11).
+			const authSessionCols = getColumnNames(freshDb, "auth_sessions");
+			for (const col of SSO_COLUMNS) {
+				expect(
+					authSessionCols,
+					`expected column "${col}" on auth_sessions after fresh Drizzle migrate`,
+				).toContain(col);
+			}
+
 			freshDb.close();
 		} finally {
 			if (originalSqlitePath === undefined) {
@@ -248,6 +267,71 @@ describeSqliteOnly("initializeDatabase boot routing — SQLite", () => {
 
 		db.close();
 	});
+
+	test("existing install (legacy path): auth_sessions has all 4 SSO identity columns (AC 11, H-2)", async () => {
+		// Simulate a pre-existing install: seed a minimal sessions table + a
+		// pre-Phase-1 auth_sessions (6 columns only) so the legacy path runs
+		// and must apply the 4 idempotent ALTER TABLE migrations.
+		const db = new Database(":memory:");
+		db.exec("PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;");
+		db.exec(`
+			CREATE TABLE sessions (
+				id TEXT PRIMARY KEY,
+				session_id TEXT NOT NULL UNIQUE,
+				agent_type TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'active',
+				started_at TEXT NOT NULL DEFAULT (datetime('now')),
+				last_activity_at TEXT NOT NULL DEFAULT (datetime('now')),
+				total_tool_uses INTEGER NOT NULL DEFAULT 0,
+				metadata TEXT DEFAULT '{}'
+			);
+			CREATE TABLE auth_sessions (
+				token_hash TEXT PRIMARY KEY,
+				user_id TEXT NOT NULL,
+				expires_at TEXT NOT NULL,
+				user_agent TEXT,
+				created_at TEXT NOT NULL DEFAULT (datetime('now')),
+				last_seen_at TEXT NOT NULL DEFAULT (datetime('now'))
+			);
+		`);
+
+		// Confirm the SSO columns are absent before the legacy init runs.
+		const colsBefore = getColumnNames(db, "auth_sessions");
+		for (const col of SSO_COLUMNS) {
+			expect(
+				colsBefore,
+				`column "${col}" should not exist on the pre-Phase-1 auth_sessions seed`,
+			).not.toContain(col);
+		}
+
+		// Run the legacy init — it should apply the ALTER TABLE migrations.
+		await initializeDatabase(db);
+
+		// All 4 SSO columns must now be present.
+		const colsAfter = getColumnNames(db, "auth_sessions");
+		for (const col of SSO_COLUMNS) {
+			expect(
+				colsAfter,
+				`expected column "${col}" on auth_sessions after legacy init (Phase 1 ALTER migrations)`,
+			).toContain(col);
+		}
+
+		// The base columns must still be present.
+		for (const col of [
+			"token_hash",
+			"user_id",
+			"expires_at",
+			"user_agent",
+			"created_at",
+			"last_seen_at",
+		]) {
+			expect(colsAfter, `base column "${col}" must survive the legacy ALTER migrations`).toContain(
+				col,
+			);
+		}
+
+		db.close();
+	});
 });
 
 // ── Postgres case (optional — requires running Postgres) ───────────────────────
@@ -304,6 +388,21 @@ describePostgresOnly("initializeDatabase boot routing — Postgres", () => {
 				expect(tableNames).toContain(t);
 			}
 			expect(tableNames).not.toContain("event_embeddings");
+
+			// Phase 1: all 4 SSO identity columns must be present on auth_sessions (AC 11).
+			const pgAuthCols = (await sql`
+				SELECT column_name
+				FROM information_schema.columns
+				WHERE table_schema = 'public'
+				  AND table_name = 'auth_sessions'
+			`) as Array<{ column_name: string }>;
+			const pgAuthColNames = pgAuthCols.map((r) => r.column_name);
+			for (const col of SSO_COLUMNS) {
+				expect(
+					pgAuthColNames,
+					`expected column "${col}" on auth_sessions in Postgres after Drizzle migrate`,
+				).toContain(col);
+			}
 
 			const cascadeFks = (await sql`
 				SELECT tc.table_name, rc.delete_rule

--- a/src/server/db/schema/core/auth-sessions.ts
+++ b/src/server/db/schema/core/auth-sessions.ts
@@ -14,6 +14,15 @@ export const authSessionsSqlite = sqliteTable("auth_sessions", {
 	userAgent: text("user_agent"),
 	createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
 	lastSeenAt: text("last_seen_at").notNull().default(sql`(datetime('now'))`),
+	// SSO identity columns (Phase 1 — Decision 1 / H-3).
+	// auth_source distinguishes local sessions from SSO-bridged sessions.
+	// sso_subject, sso_username, provider are null for local sessions; set by
+	// the forwardauth bridge (Phase 4). user_id stays notNull (stores
+	// "sso:"+subject for SSO rows; nothing parses it — callers read sso_subject).
+	authSource: text("auth_source").notNull().default("local"),
+	ssoSubject: text("sso_subject"),
+	ssoUsername: text("sso_username"),
+	provider: text("provider"),
 });
 
 export const authSessionsPg = pgTable("auth_sessions", {
@@ -23,4 +32,9 @@ export const authSessionsPg = pgTable("auth_sessions", {
 	userAgent: pgText("user_agent"),
 	createdAt: tsColumn("postgres", "created_at"),
 	lastSeenAt: tsColumn("postgres", "last_seen_at"),
+	// SSO identity columns (Phase 1 — Decision 1 / H-3).
+	authSource: pgText("auth_source").notNull().default("local"),
+	ssoSubject: pgText("sso_subject"),
+	ssoUsername: pgText("sso_username"),
+	provider: pgText("provider"),
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -99,15 +99,16 @@ if (process.env.AGENTPULSE_AUTHENTIK_TRUST_SECRET && !process.env.FORWARDAUTH_TR
 	);
 }
 
-// Advisory: operators should configure the forwardauth trust secret in production.
-// Without it, any request that carries forwardauth identity headers (e.g. from a
-// compromised sibling pod) bypasses the trust gate. NetworkPolicy from P10 narrows
-// but does not eliminate this attack surface.
+// Without a forwardauth trust secret the trust gate is fail-closed:
+// verifyForwardauthSecret returns false, so all forwardauth identity headers
+// are rejected and SSO sign-in will not work. This is a misconfiguration
+// warning, not a security bypass — the behavior is stricter than expected,
+// not looser.
 if (!config.forwardauthTrustSecret && !config.disableAuth) {
 	console.warn(
-		"[security] FORWARDAUTH_TRUST_SECRET is not set. The forwardauth header trust gate is disabled. " +
-			"Any request carrying forwardauth identity headers will be accepted without verification. " +
-			"Set FORWARDAUTH_TRUST_SECRET to a shared secret (see deploy/k8s/FORWARDAUTH.md).",
+		"[config] FORWARDAUTH_TRUST_SECRET is not set. The forwardauth trust gate is fail-closed: " +
+			"all forwardauth identity headers are rejected and SSO sign-in will not work. " +
+			"Set FORWARDAUTH_TRUST_SECRET to the shared secret configured in your ingress (see deploy/k8s/FORWARDAUTH.md).",
 	);
 }
 

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -182,13 +182,18 @@ export function checkPasswordComplexity(password: string): string | null {
  */
 const authRouter = new Hono();
 
-function cookieOptions() {
+/**
+ * Cookie attributes for `ap_session`. The `durationMs` param lets the Phase 4
+ * SSO bridge pass `SSO_SESSION_DURATION_MS` (8h) while all three existing local
+ * callers keep passing nothing (defaulting to SESSION_DURATION_MS = 30d).
+ */
+export function cookieOptions(durationMs = SESSION_DURATION_MS) {
 	return {
 		path: "/",
 		httpOnly: true,
 		secure: config.isProduction,
 		sameSite: "Lax" as const,
-		maxAge: Math.floor(SESSION_DURATION_MS / 1000),
+		maxAge: Math.floor(durationMs / 1000),
 	};
 }
 

--- a/src/server/routes/supervisors-split.test.ts
+++ b/src/server/routes/supervisors-split.test.ts
@@ -1,0 +1,152 @@
+/**
+ * AC 9 — supervisor route-split (Phase 3)
+ *
+ * Verifies:
+ *  1. Old management path /api/v1/supervisors/enroll → 404 (edge-public path no
+ *     longer mints tokens).
+ *  2. Admin router enforces requireAuth(): /api/v1/admin/supervisors/enroll
+ *     with no auth → 401.
+ *  3. Agent endpoints under /api/v1/supervisors/* still work (register reachable;
+ *     auth is enforced in-handler, not by the route split itself).
+ *  4. Admin endpoints with a valid auth session → reach the handler (201 from enroll).
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import "../db/__test_db.js";
+
+const { config } = await import("../config.js");
+const { initializeDatabase } = await import("../db/client.js");
+const { Hono } = await import("hono");
+const { supervisorsAgentRouter, supervisorsAdminRouter } = await import("./supervisors.js");
+const { createUser, issueSession, SESSION_DURATION_MS } = await import(
+	"../services/local-auth-service.js"
+);
+
+// Mirror the real app.ts mount:
+//   agent router at /api/v1        → /api/v1/supervisors/*
+//   admin router at /api/v1/admin  → /api/v1/admin/supervisors/*
+const app = new Hono()
+	.route("/api/v1", supervisorsAgentRouter)
+	.route("/api/v1/admin", supervisorsAdminRouter);
+
+const originalDisableAuth = config.disableAuth;
+
+beforeAll(async () => {
+	await initializeDatabase();
+	// Ensure auth is enforced for these tests.
+	(config as Record<string, unknown>).disableAuth = false;
+});
+
+afterAll(() => {
+	(config as Record<string, unknown>).disableAuth = originalDisableAuth;
+});
+
+// ── AC 9.1: old path /api/v1/supervisors/enroll → 404 ────────────────────────
+describe("old management path is gone (AC 9.1)", () => {
+	test("POST /api/v1/supervisors/enroll → 404", async () => {
+		const res = await app.request("/api/v1/supervisors/enroll", { method: "POST" });
+		expect(res.status).toBe(404);
+	});
+
+	test("GET /api/v1/supervisors → 404 (list no longer on agent router)", async () => {
+		const res = await app.request("/api/v1/supervisors", { method: "GET" });
+		expect(res.status).toBe(404);
+	});
+
+	test("POST /api/v1/supervisors/fake-id/rotate → 404", async () => {
+		const res = await app.request("/api/v1/supervisors/fake-id/rotate", { method: "POST" });
+		expect(res.status).toBe(404);
+	});
+
+	test("POST /api/v1/supervisors/fake-id/revoke → 404", async () => {
+		const res = await app.request("/api/v1/supervisors/fake-id/revoke", { method: "POST" });
+		expect(res.status).toBe(404);
+	});
+});
+
+// ── AC 9.2: admin router enforces requireAuth() ───────────────────────────────
+describe("admin router requires auth (AC 9.2)", () => {
+	test("POST /api/v1/admin/supervisors/enroll with no auth → 401", async () => {
+		const res = await app.request("/api/v1/admin/supervisors/enroll", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(401);
+	});
+
+	test("GET /api/v1/admin/supervisors with no auth → 401", async () => {
+		const res = await app.request("/api/v1/admin/supervisors", { method: "GET" });
+		expect(res.status).toBe(401);
+	});
+
+	test("POST /api/v1/admin/supervisors/fake-id/rotate with no auth → 401", async () => {
+		const res = await app.request("/api/v1/admin/supervisors/fake-id/rotate", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(401);
+	});
+
+	test("POST /api/v1/admin/supervisors/fake-id/revoke with no auth → 401", async () => {
+		const res = await app.request("/api/v1/admin/supervisors/fake-id/revoke", {
+			method: "POST",
+		});
+		expect(res.status).toBe(401);
+	});
+});
+
+// ── AC 9.3: agent endpoints still reachable ───────────────────────────────────
+describe("agent endpoints still reachable on /api/v1/supervisors (AC 9.3)", () => {
+	test("POST /api/v1/supervisors/register without token → 401 (in-handler auth)", async () => {
+		// register is on the agent router; with auth enabled and no credential it
+		// returns 401 from in-handler logic, NOT 404 (proves the route is mounted).
+		const res = await app.request("/api/v1/supervisors/register", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				hostName: "test",
+				platform: "linux",
+				arch: "x64",
+				version: "1.0.0",
+			}),
+		});
+		// 401 = route found, in-handler auth fired (not 404)
+		expect(res.status).toBe(401);
+	});
+
+	test("POST /api/v1/supervisors/fake-id/heartbeat without supervisor token → 401", async () => {
+		const res = await app.request("/api/v1/supervisors/fake-id/heartbeat", {
+			method: "POST",
+		});
+		// requireSupervisorAuth() fires → 401, not 404
+		expect(res.status).toBe(401);
+	});
+});
+
+// ── AC 9.4: admin handler reachable with valid session ────────────────────────
+describe("admin handler reachable with valid local session (AC 9.4)", () => {
+	test("POST /api/v1/admin/supervisors/enroll with valid session → 201", async () => {
+		// Create a real local user, then issue a session for it.
+		const user = await createUser({
+			username: "testadmin",
+			password: "TestPass123!",
+			role: "user",
+		});
+		const { token } = await issueSession({
+			userId: user.id,
+			durationMs: SESSION_DURATION_MS,
+		});
+		const res = await app.request("/api/v1/admin/supervisors/enroll", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: `ap_session=${token}`,
+			},
+			body: JSON.stringify({ name: "test-supervisor" }),
+		});
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { token: string };
+		expect(typeof body.token).toBe("string");
+	});
+});

--- a/src/server/routes/supervisors.ts
+++ b/src/server/routes/supervisors.ts
@@ -33,21 +33,26 @@ import {
 	revokeSupervisor,
 } from "../services/supervisor-registry.js";
 
-const supervisorsRouter = new Hono();
+// ── Dashboard-management router (requireAuth) ─────────────────────────────────
+// Mounted at /api/v1/admin/supervisors — falls through to the forwardauth
+// catch-all IngressRoute rule so SSO sessions carry live IdP revocation.
+// /api/v1/admin/* is intentionally NOT in the IngressRoute exemption list.
 
-supervisorsRouter.get("/supervisors", requireAuth(), async (c) => {
+const supervisorsAdminRouter = new Hono();
+
+supervisorsAdminRouter.get("/supervisors", requireAuth(), async (c) => {
 	const supervisors = await listSupervisors();
 	return c.json({ supervisors, total: supervisors.length });
 });
 
-supervisorsRouter.get("/supervisors/:id", requireAuth(), async (c) => {
+supervisorsAdminRouter.get("/supervisors/:id", requireAuth(), async (c) => {
 	const supervisorId = c.req.param("id") ?? "";
 	const supervisor = await getSupervisor(supervisorId);
 	if (!supervisor) return c.json({ error: "Supervisor not found" }, 404);
 	return c.json({ supervisor });
 });
 
-supervisorsRouter.post("/supervisors/enroll", requireAuth(), async (c) => {
+supervisorsAdminRouter.post("/supervisors/enroll", requireAuth(), async (c) => {
 	const body = await c.req.json<{
 		name?: string;
 		expiresAt?: string | null;
@@ -61,7 +66,7 @@ supervisorsRouter.post("/supervisors/enroll", requireAuth(), async (c) => {
 	return c.json(result, 201);
 });
 
-supervisorsRouter.post("/supervisors/:id/rotate", requireAuth(), async (c) => {
+supervisorsAdminRouter.post("/supervisors/:id/rotate", requireAuth(), async (c) => {
 	const supervisorId = c.req.param("id") ?? "";
 	const supervisor = await getSupervisor(supervisorId);
 	if (!supervisor) return c.json({ error: "Supervisor not found" }, 404);
@@ -74,7 +79,21 @@ supervisorsRouter.post("/supervisors/:id/rotate", requireAuth(), async (c) => {
 	return c.json(result, 201);
 });
 
-supervisorsRouter.post("/supervisors/register", async (c) => {
+supervisorsAdminRouter.post("/supervisors/:id/revoke", requireAuth(), async (c) => {
+	const supervisorId = c.req.param("id") ?? "";
+	await revokeSupervisor(supervisorId);
+	await revokeSupervisorCredential(supervisorId);
+	return c.json({ ok: true });
+});
+
+// ── Machine-agent router (requireSupervisorAuth / enrollment-token) ───────────
+// Mounted at /api/v1/supervisors — edge-public (exempt from forwardauth).
+// Each endpoint carries explicit in-process auth; supervisor agents running on
+// remote machines cannot hold an SSO session.
+
+const supervisorsAgentRouter = new Hono();
+
+supervisorsAgentRouter.post("/supervisors/register", async (c) => {
 	const body = await c.req.json<SupervisorRegistrationInput>();
 	const registrationInput: SupervisorRegistrationInput = { ...body };
 	if (
@@ -134,27 +153,24 @@ supervisorsRouter.post("/supervisors/register", async (c) => {
 	return c.json(result);
 });
 
-supervisorsRouter.post("/supervisors/:id/revoke", requireAuth(), async (c) => {
-	const supervisorId = c.req.param("id") ?? "";
-	await revokeSupervisor(supervisorId);
-	await revokeSupervisorCredential(supervisorId);
-	return c.json({ ok: true });
-});
-
-supervisorsRouter.post("/supervisors/:id/heartbeat", requireSupervisorAuth(), async (c) => {
+supervisorsAgentRouter.post("/supervisors/:id/heartbeat", requireSupervisorAuth(), async (c) => {
 	const supervisorId = c.req.param("id") ?? "";
 	const supervisor = await heartbeatSupervisor(supervisorId);
 	if (!supervisor) return c.json({ error: "Supervisor not found" }, 404);
 	return c.json({ supervisor });
 });
 
-supervisorsRouter.post("/supervisors/:id/launches/claim", requireSupervisorAuth(), async (c) => {
-	const supervisorId = c.req.param("id") ?? "";
-	const launchRequest = await claimNextLaunchRequest(supervisorId);
-	return c.json({ launchRequest: launchRequest ?? null });
-});
+supervisorsAgentRouter.post(
+	"/supervisors/:id/launches/claim",
+	requireSupervisorAuth(),
+	async (c) => {
+		const supervisorId = c.req.param("id") ?? "";
+		const launchRequest = await claimNextLaunchRequest(supervisorId);
+		return c.json({ launchRequest: launchRequest ?? null });
+	},
+);
 
-supervisorsRouter.post(
+supervisorsAgentRouter.post(
 	"/supervisors/:id/launches/:launchId/status",
 	requireSupervisorAuth(),
 	async (c) => {
@@ -179,7 +195,7 @@ supervisorsRouter.post(
 	},
 );
 
-supervisorsRouter.post(
+supervisorsAgentRouter.post(
 	"/supervisors/:id/managed-session-state",
 	requireSupervisorAuth(),
 	async (c) => {
@@ -193,7 +209,7 @@ supervisorsRouter.post(
 	},
 );
 
-supervisorsRouter.post(
+supervisorsAgentRouter.post(
 	"/supervisors/:id/managed-sessions/:sessionId/events",
 	requireSupervisorAuth(),
 	async (c) => {
@@ -209,13 +225,13 @@ supervisorsRouter.post(
 	},
 );
 
-supervisorsRouter.get("/supervisors/:id/provider-sync", requireSupervisorAuth(), async (c) => {
+supervisorsAgentRouter.get("/supervisors/:id/provider-sync", requireSupervisorAuth(), async (c) => {
 	const supervisorId = c.req.param("id") ?? "";
 	const managedSessions = await listManagedSessionsNeedingSync(supervisorId);
 	return c.json({ managedSessions });
 });
 
-supervisorsRouter.post(
+supervisorsAgentRouter.post(
 	"/supervisors/:id/control-actions/claim",
 	requireSupervisorAuth(),
 	async (c) => {
@@ -225,7 +241,7 @@ supervisorsRouter.post(
 	},
 );
 
-supervisorsRouter.post(
+supervisorsAgentRouter.post(
 	"/supervisors/:id/control-actions/:actionId/status",
 	requireSupervisorAuth(),
 	async (c) => {
@@ -248,4 +264,4 @@ supervisorsRouter.post(
 	},
 );
 
-export { supervisorsRouter };
+export { supervisorsAgentRouter, supervisorsAdminRouter };

--- a/src/server/services/ai/run-leaser.test.ts
+++ b/src/server/services/ai/run-leaser.test.ts
@@ -1,0 +1,169 @@
+/**
+ * RunLeaser unit tests.
+ *
+ * Covers:
+ *   1. Drain processes every queued run and terminates when the queue is empty.
+ *   2. Busy guard blocks re-entrant drain calls (timer-fires-while-busy pattern).
+ *   3. Empty queue returns immediately with no processRun calls.
+ *   4. Macrotask yield — the core fix for the bun event-loop soft-lockup
+ *      (see thoughts/shared/investigations/active/2026-06-29-diagnose-bun-soft-lockup.md).
+ *      A macrotask scheduled before drain starts must fire BETWEEN two processed
+ *      runs, not after drain completes — proving the yield surrenders the event
+ *      loop between iterations.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import "./__test_db.js";
+
+const { getDb, initializeDatabase } = await import("../../db/client.js");
+const { enqueueRun } = await import("./watcher-runs-service.js");
+const { aiWatcherRuns, sessions } = await import("../../db/schema/index.js");
+const { RunLeaser } = await import("./run-leaser.js");
+
+const SESSION_IDS = ["rl-s1", "rl-s2", "rl-s3"];
+
+beforeAll(async () => {
+	await initializeDatabase();
+});
+
+beforeEach(async () => {
+	await getDb().delete(aiWatcherRuns).execute();
+	await getDb().delete(sessions).execute();
+	for (const id of SESSION_IDS) {
+		await getDb()
+			.insert(sessions)
+			.values({ sessionId: id, agentType: "claude_code" })
+			.onConflictDoNothing();
+	}
+});
+
+describe("RunLeaser.drain", () => {
+	test("processes all queued runs and terminates when queue is empty", async () => {
+		for (const id of SESSION_IDS) {
+			await enqueueRun({ sessionId: id, triggerKind: "idle" });
+		}
+
+		const processed: string[] = [];
+		const leaser = new RunLeaser({
+			leaseOwner: "test-owner",
+			leaseDurationMs: 10_000,
+			intervalMs: 60_000,
+			shouldRun: async () => true,
+			processRun: async (run) => {
+				processed.push(run.sessionId);
+			},
+		});
+
+		await leaser.drain();
+
+		expect(processed).toHaveLength(3);
+		expect(new Set(processed)).toEqual(new Set(SESSION_IDS));
+	});
+
+	test("busy guard blocks re-entrant drain called while drain is active", async () => {
+		// This reproduces the production pattern: setInterval fires while a drain
+		// is already in progress. The busy flag is set before the while loop, so
+		// the re-entrant call sees busy=true and returns immediately.
+		await enqueueRun({ sessionId: "rl-s1", triggerKind: "idle" });
+
+		let processCallCount = 0;
+		let reentrancyAttempted = false;
+		// Structural type so the closure can reference the leaser without a
+		// circular initializer; RunLeaser from a dynamic import can't be used
+		// directly as a type annotation.
+		let leaserRef: { drain(): Promise<void> } = {
+			drain: async () => {},
+		};
+
+		const leaser = new RunLeaser({
+			leaseOwner: "test-owner",
+			leaseDurationMs: 10_000,
+			intervalMs: 60_000,
+			shouldRun: async () => true,
+			processRun: async (_run) => {
+				processCallCount++;
+				reentrancyAttempted = true;
+				// Simulate the interval timer firing while drain is already running.
+				// this.busy is true at this point, so the second call must return
+				// immediately without processing any runs.
+				void leaserRef.drain();
+			},
+		});
+		leaserRef = leaser;
+
+		await leaser.drain();
+
+		expect(reentrancyAttempted).toBe(true);
+		// Re-entrant drain was blocked: processRun called exactly once.
+		expect(processCallCount).toBe(1);
+	});
+
+	test("empty queue returns immediately without calling processRun", async () => {
+		const processed: string[] = [];
+		const leaser = new RunLeaser({
+			leaseOwner: "test-owner",
+			leaseDurationMs: 10_000,
+			intervalMs: 60_000,
+			shouldRun: async () => true,
+			processRun: async (run) => {
+				processed.push(run.sessionId);
+			},
+		});
+
+		await leaser.drain();
+
+		expect(processed).toHaveLength(0);
+	});
+
+	test("yield surrenders the event loop between runs (macrotask-starvation fix)", async () => {
+		// Root cause: without the yield, bun:sqlite Promises resolve as microtasks
+		// so the while(true) loop drains the entire queue in one unbroken microtask
+		// burst — a macrotask scheduled before drain starts could only fire AFTER
+		// drain completes, starving timers and I/O.
+		//
+		// Fix: `await new Promise(r => setTimeout(r, 0))` after each processRun
+		// surrenders to the macrotask queue. Because the pre-scheduled macrotask
+		// was enqueued first, it fires before the yield's own resolve — meaning it
+		// fires BETWEEN run-1 and run-2, not after the drain finishes.
+		//
+		// Assertion: macrotaskIdx > runIndices[0]  (fired after first run)
+		//             macrotaskIdx < runIndices[last] (fired before last run)
+		// Without the yield both conditions would fail (macrotask fires last).
+
+		await enqueueRun({ sessionId: "rl-s1", triggerKind: "idle" });
+		await enqueueRun({ sessionId: "rl-s2", triggerKind: "idle" });
+
+		const order: string[] = [];
+
+		// Schedule before drain. With the yield this fires between run-1 and run-2
+		// because: (a) it's already in the macrotask queue when the first yield
+		// schedules its own resolve, and (b) Bun drains the macrotask queue FIFO,
+		// so the pre-scheduled callback wins the next macrotask slot.
+		setTimeout(() => order.push("macrotask"), 0);
+
+		const leaser = new RunLeaser({
+			leaseOwner: "test-owner",
+			leaseDurationMs: 10_000,
+			intervalMs: 60_000,
+			shouldRun: async () => true,
+			processRun: async (run) => {
+				order.push(`run-${run.sessionId}`);
+			},
+		});
+
+		await leaser.drain();
+
+		// Both runs must have been processed.
+		const runIndices = order
+			.map((s, i) => ({ s, i }))
+			.filter(({ s }) => s.startsWith("run-"))
+			.map(({ i }) => i);
+
+		expect(runIndices).toHaveLength(2);
+
+		// Macrotask must have fired: between first and last run.
+		const macrotaskIdx = order.indexOf("macrotask");
+		expect(macrotaskIdx).toBeGreaterThan(runIndices[0]); // after first run
+		expect(macrotaskIdx).toBeLessThan(runIndices[runIndices.length - 1]); // before last run
+	});
+});

--- a/src/server/services/ai/run-leaser.ts
+++ b/src/server/services/ai/run-leaser.ts
@@ -80,6 +80,14 @@ export class RunLeaser {
 				});
 				if (!run) return;
 				await this.opts.processRun(run);
+				// Yield to the macrotask queue between runs so timers and I/O can
+				// make progress. bun:sqlite Promises resolve synchronously in C++ and
+				// are surfaced as microtasks; without this yield the while(true) loop
+				// never relinquishes the event loop — under load it pins a vCPU and
+				// can trigger a kernel soft-lockup. Mirrors the pattern in
+				// embeddings/embedding-service.ts. The empty-queue `return` above
+				// executes before this yield so idle polls have zero overhead.
+				await new Promise<void>((resolve) => setTimeout(resolve, 0));
 			}
 		} catch (err) {
 			console.error("[run-leaser] drain failed:", err);

--- a/src/server/services/local-auth-service.test.ts
+++ b/src/server/services/local-auth-service.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Phase 2 — local-auth-service + getAuthUserFromHeaders integration tests.
+ *
+ * Uses a real in-memory SQLite DB seeded via initializeDatabase() so that
+ * issueSession/resolveSessionByToken exercise the actual schema (including the
+ * Phase 1 SSO columns). No mocks for getDb, hashToken, verifyApiKey, or
+ * verifyForwardauthSecret — real implementations only.
+ *
+ * Tests cover:
+ *   - Local session round-trip: issueSession → resolveSessionByToken → {kind:"local"}
+ *   - getAuthUserFromHeaders with local cookie → source:"local" + role (parity)
+ *   - SSO session round-trip: issueSession (SSO fields) → {kind:"sso"}
+ *   - getAuthUserFromHeaders with SSO cookie only → source:"forwardauth", no role
+ *   - Expired SSO session → null + row deleted
+ *   - Bearer precedence (AC 12 / Decision 8)
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import "../db/__test_db.js";
+
+const { initializeDatabase } = await import("../db/client.js");
+const {
+	SESSION_DURATION_MS,
+	SSO_SESSION_DURATION_MS,
+	createUser,
+	issueSession,
+	resolveSessionByToken,
+} = await import("./local-auth-service.js");
+const { getAuthUserFromHeaders } = await import("../auth/middleware.js");
+const { createApiKey } = await import("../auth/api-key.js");
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+	await initializeDatabase();
+});
+
+// Helper: build a minimal Headers mock carrying only a cookie.
+function cookieHeaders(cookieValue: string): { get(name: string): string | null } {
+	return {
+		get(name: string) {
+			if (name === "cookie" || name === "Cookie") return cookieValue;
+			return null;
+		},
+	};
+}
+
+// Helper: build a Headers mock with a cookie AND an Authorization header.
+function authHeaders(
+	cookieValue: string,
+	authorization: string,
+): { get(name: string): string | null } {
+	return {
+		get(name: string) {
+			if (name === "cookie" || name === "Cookie") return cookieValue;
+			if (name === "Authorization") return authorization;
+			return null;
+		},
+	};
+}
+
+// ── Local session round-trip ──────────────────────────────────────────────────
+
+describe("local session: issueSession → resolveSessionByToken", () => {
+	test("issueSession (local defaults) → resolveSessionByToken → {kind:'local'}", async () => {
+		const user = await createUser({
+			username: "testlocal1",
+			password: "S3cur3P@ssword!",
+		});
+
+		const { token } = await issueSession({ userId: user.id, userAgent: "test" });
+		const resolved = await resolveSessionByToken(token);
+
+		expect(resolved).not.toBeNull();
+		expect(resolved?.kind).toBe("local");
+		if (resolved?.kind === "local") {
+			expect(resolved.user.id).toBe(user.id);
+			expect(resolved.user.username).toBe("testlocal1");
+			expect(resolved.user.role).toBe("user");
+		}
+	});
+
+	test("getAuthUserFromHeaders with local cookie → source:'local' + role (parity check)", async () => {
+		const user = await createUser({
+			username: "testlocal2",
+			password: "S3cur3P@ssword!",
+		});
+		const { token } = await issueSession({ userId: user.id });
+
+		const result = await getAuthUserFromHeaders(cookieHeaders(`ap_session=${token}`));
+
+		expect(result).not.toBeNull();
+		expect(result?.source).toBe("local");
+		expect(result?.name).toBe("testlocal2");
+		expect(result?.id).toBe(user.id);
+		expect(result?.role).toBe("user");
+	});
+
+	test("unknown token → null", async () => {
+		const result = await resolveSessionByToken("0".repeat(64));
+		expect(result).toBeNull();
+	});
+
+	test("empty token → null", async () => {
+		const result = await resolveSessionByToken("");
+		expect(result).toBeNull();
+	});
+});
+
+// ── SSO session round-trip ────────────────────────────────────────────────────
+
+describe("SSO session: issueSession (SSO fields) → resolveSessionByToken", () => {
+	test("issueSession with SSO fields → {kind:'sso'} with correct subject/username/provider", async () => {
+		const subject = "uid-abc-123";
+		const username = "alice@example.com";
+		const provider = "authentik";
+
+		const { token } = await issueSession({
+			userId: `sso:${subject}`,
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: subject,
+			ssoUsername: username,
+			provider,
+		});
+
+		const resolved = await resolveSessionByToken(token);
+
+		expect(resolved).not.toBeNull();
+		expect(resolved?.kind).toBe("sso");
+		if (resolved?.kind === "sso") {
+			expect(resolved.subject).toBe(subject);
+			expect(resolved.username).toBe(username);
+			expect(resolved.provider).toBe(provider);
+		}
+	});
+
+	test("getAuthUserFromHeaders with SSO cookie only → source:'forwardauth', no role", async () => {
+		const subject = "uid-sso-getauth";
+		const username = "bob@example.com";
+
+		const { token } = await issueSession({
+			userId: `sso:${subject}`,
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: subject,
+			ssoUsername: username,
+			provider: "authentik",
+		});
+
+		const result = await getAuthUserFromHeaders(cookieHeaders(`ap_session=${token}`));
+
+		expect(result).not.toBeNull();
+		expect(result?.source).toBe("forwardauth");
+		expect(result?.provider).toBe("authentik");
+		expect(result?.name).toBe(username);
+		expect(result?.id).toBe(subject);
+		// SSO sessions carry no role (Decision 4).
+		expect(result?.role).toBeUndefined();
+	});
+});
+
+// ── Null-subject SSO guard (xander L-2) ──────────────────────────────────────
+
+describe("SSO session with null sso_subject → resolveSessionByToken returns null", () => {
+	test("SSO row missing ssoSubject → null (malformed identity rejected, not emitted as id:'')", async () => {
+		// Issue a session that looks like an SSO row but with no subject — simulates
+		// a bug or a manually-crafted row. The resolver must not emit {kind:"sso",subject:""}.
+		const { token } = await issueSession({
+			userId: "sso:no-subject",
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: null, // ← the malformed condition
+			ssoUsername: "ghost@example.com",
+			provider: "authentik",
+		});
+
+		const resolved = await resolveSessionByToken(token);
+		// Must be null — not {kind:"sso",subject:"", ...}.
+		expect(resolved).toBeNull();
+	});
+
+	test("getAuthUserFromHeaders with a subject-less SSO cookie → null (not source:'forwardauth' with id:'')", async () => {
+		const { token } = await issueSession({
+			userId: "sso:no-subject-auth",
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: null,
+			ssoUsername: "ghost2@example.com",
+			provider: "authentik",
+		});
+
+		const result = await getAuthUserFromHeaders(cookieHeaders(`ap_session=${token}`));
+		expect(result).toBeNull();
+	});
+});
+
+// ── Expiry ────────────────────────────────────────────────────────────────────
+
+describe("expired SSO session → null + row deleted", () => {
+	test("resolveSessionByToken on an expired SSO token returns null and deletes the row", async () => {
+		const subject = "uid-expired-sso";
+		// Issue with a TTL of 1ms so it's already expired by the time we resolve.
+		const { token } = await issueSession({
+			userId: `sso:${subject}`,
+			durationMs: 1,
+			authSource: "forwardauth",
+			ssoSubject: subject,
+			ssoUsername: "expired@example.com",
+			provider: "authentik",
+		});
+
+		// Brief sleep to ensure expiry has passed.
+		await Bun.sleep(5);
+
+		const resolved = await resolveSessionByToken(token);
+		expect(resolved).toBeNull();
+
+		// Confirm row is gone — a second resolve should also return null (not
+		// because it's re-deleted but because it was deleted on the first call).
+		const second = await resolveSessionByToken(token);
+		expect(second).toBeNull();
+	});
+
+	test("expired local session → null and row deleted", async () => {
+		const user = await createUser({
+			username: "testexpired1",
+			password: "S3cur3P@ssword!",
+		});
+		const { token } = await issueSession({ userId: user.id, durationMs: 1 });
+
+		await Bun.sleep(5);
+
+		const resolved = await resolveSessionByToken(token);
+		expect(resolved).toBeNull();
+	});
+});
+
+// ── Bearer precedence (AC 12 / Decision 8) ───────────────────────────────────
+
+describe("Bearer precedence — `Bearer ap_*` is authoritative (AC 12)", () => {
+	test("valid SSO cookie + Authorization: Bearer ap_<invalid> → null (Bearer short-circuits; cookie NOT consulted)", async () => {
+		// Mint a valid SSO session.
+		const subject = "uid-bearer-test";
+		const { token: cookieToken } = await issueSession({
+			userId: `sso:${subject}`,
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: subject,
+			ssoUsername: "charlie@example.com",
+			provider: "authentik",
+		});
+
+		// Sanity: cookie alone resolves correctly.
+		const cookieOnly = await getAuthUserFromHeaders(cookieHeaders(`ap_session=${cookieToken}`));
+		expect(cookieOnly?.source).toBe("forwardauth");
+
+		// Now add a syntactically valid-looking but unknown Bearer key.
+		const withBadBearer = await getAuthUserFromHeaders(
+			authHeaders(`ap_session=${cookieToken}`, "Bearer ap_invalidkeyvalue000000000"),
+		);
+		// The invalid Bearer must short-circuit — returns null, NOT the SSO identity.
+		expect(withBadBearer).toBeNull();
+	});
+
+	test("valid real API key → source:'api_key' regardless of cookie presence", async () => {
+		// Create a real API key in the DB.
+		const { key: realKey } = await createApiKey("phase2-test-key");
+
+		const subject = "uid-bearer-realkey";
+		const { token: cookieToken } = await issueSession({
+			userId: `sso:${subject}`,
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: subject,
+			ssoUsername: "dave@example.com",
+			provider: "authentik",
+		});
+
+		const result = await getAuthUserFromHeaders(
+			authHeaders(`ap_session=${cookieToken}`, `Bearer ${realKey}`),
+		);
+
+		expect(result).not.toBeNull();
+		expect(result?.source).toBe("api_key");
+	});
+
+	test("cookie only (no Authorization header) → resolves the cookie identity (unchanged flow)", async () => {
+		const user = await createUser({
+			username: "testbearer3",
+			password: "S3cur3P@ssword!",
+		});
+		const { token } = await issueSession({ userId: user.id });
+
+		const result = await getAuthUserFromHeaders(cookieHeaders(`ap_session=${token}`));
+
+		expect(result).not.toBeNull();
+		expect(result?.source).toBe("local");
+		expect(result?.name).toBe("testbearer3");
+	});
+
+	test("Bearer ap_<invalid> with NO cookie → null", async () => {
+		const result = await getAuthUserFromHeaders({
+			get(name: string) {
+				if (name === "Authorization") return "Bearer ap_totallyfakekey000000000000";
+				return null;
+			},
+		});
+		expect(result).toBeNull();
+	});
+
+	test("valid local cookie + Bearer ap_<invalid> → null (local session NOT consulted)", async () => {
+		// Regression: confirm local-session cookie is also NOT a fallback when
+		// an invalid ap_ Bearer is presented (same Decision 8 invariant).
+		const user = await createUser({
+			username: "testbearer5",
+			password: "S3cur3P@ssword!",
+		});
+		const { token } = await issueSession({ userId: user.id });
+
+		// Sanity: cookie alone works.
+		const cookieOnly = await getAuthUserFromHeaders(cookieHeaders(`ap_session=${token}`));
+		expect(cookieOnly?.source).toBe("local");
+
+		// With an invalid Bearer, must return null.
+		const withBad = await getAuthUserFromHeaders(
+			authHeaders(`ap_session=${token}`, "Bearer ap_invalidkeyvalue000000000"),
+		);
+		expect(withBad).toBeNull();
+	});
+});
+
+// ── SSO_SESSION_DURATION_MS export ───────────────────────────────────────────
+
+describe("SSO_SESSION_DURATION_MS", () => {
+	test("defaults to 8 hours when env var is not set", () => {
+		// If the env var wasn't set at import time, the default is 8h.
+		// We can't mutate env vars and re-import in bun:test's module cache,
+		// so we just assert the value is reasonable (8h = 28_800_000ms).
+		// The env-override path is covered by the constant definition itself.
+		expect(SSO_SESSION_DURATION_MS).toBeGreaterThan(0);
+		expect(SSO_SESSION_DURATION_MS).toBeLessThanOrEqual(SESSION_DURATION_MS); // ≤ 30d
+		// Default (no env var set in test process) is exactly 8h.
+		if (!process.env.AGENTPULSE_SSO_SESSION_DURATION_MS) {
+			expect(SSO_SESSION_DURATION_MS).toBe(8 * 60 * 60 * 1000);
+		}
+	});
+});

--- a/src/server/services/local-auth-service.test.ts
+++ b/src/server/services/local-auth-service.test.ts
@@ -35,28 +35,19 @@ beforeAll(async () => {
 	await initializeDatabase();
 });
 
-// Helper: build a minimal Headers mock carrying only a cookie.
-function cookieHeaders(cookieValue: string): { get(name: string): string | null } {
-	return {
-		get(name: string) {
-			if (name === "cookie" || name === "Cookie") return cookieValue;
-			return null;
-		},
-	};
+// Helper: build a real Headers object carrying only a cookie.
+function cookieHeaders(cookieValue: string): Headers {
+	const h = new Headers();
+	h.set("Cookie", cookieValue);
+	return h;
 }
 
-// Helper: build a Headers mock with a cookie AND an Authorization header.
-function authHeaders(
-	cookieValue: string,
-	authorization: string,
-): { get(name: string): string | null } {
-	return {
-		get(name: string) {
-			if (name === "cookie" || name === "Cookie") return cookieValue;
-			if (name === "Authorization") return authorization;
-			return null;
-		},
-	};
+// Helper: build a real Headers object with a cookie AND an Authorization header.
+function authHeaders(cookieValue: string, authorization: string): Headers {
+	const h = new Headers();
+	h.set("Cookie", cookieValue);
+	h.set("Authorization", authorization);
+	return h;
 }
 
 // ── Local session round-trip ──────────────────────────────────────────────────
@@ -300,12 +291,9 @@ describe("Bearer precedence — `Bearer ap_*` is authoritative (AC 12)", () => {
 	});
 
 	test("Bearer ap_<invalid> with NO cookie → null", async () => {
-		const result = await getAuthUserFromHeaders({
-			get(name: string) {
-				if (name === "Authorization") return "Bearer ap_totallyfakekey000000000000";
-				return null;
-			},
-		});
+		const h = new Headers();
+		h.set("Authorization", "Bearer ap_totallyfakekey000000000000");
+		const result = await getAuthUserFromHeaders(h);
 		expect(result).toBeNull();
 	});
 

--- a/src/server/services/local-auth-service.ts
+++ b/src/server/services/local-auth-service.ts
@@ -13,6 +13,10 @@ import { authSessions, users } from "../db/schema/index.js";
 
 export const SESSION_COOKIE_NAME = "ap_session";
 export const SESSION_DURATION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+/** SSO sessions are short-lived (default 8h). Env-tunable: AGENTPULSE_SSO_SESSION_DURATION_MS. */
+export const SSO_SESSION_DURATION_MS = process.env.AGENTPULSE_SSO_SESSION_DURATION_MS
+	? Number(process.env.AGENTPULSE_SSO_SESSION_DURATION_MS)
+	: 8 * 60 * 60 * 1000; // 8 hours
 
 export interface LocalUser {
 	id: string;
@@ -134,18 +138,47 @@ export interface IssuedSession {
 	expiresAt: string;
 }
 
+/**
+ * Discriminated-union result from resolveSessionByToken.
+ * Callers (e.g. getAuthUserFromHeaders step-2) branch on `kind` and map to
+ * AuthUser without needing to import AuthUser here (no circular dep).
+ */
+export type SessionResolution =
+	| { kind: "local"; user: LocalUser }
+	| { kind: "sso"; subject: string; username: string; provider: string };
+
 function hashToken(token: string): string {
 	return createHash("sha256").update(token).digest("hex");
 }
 
-/** Issue a new session for a user. Returns the raw token (set in cookie). */
+/**
+ * Issue a new session. Returns the raw token (caller sets it in a cookie).
+ *
+ * Local sessions:   issueSession({ userId, userAgent })
+ * SSO sessions:     issueSession({ userId:"sso:"+subject, durationMs:SSO_SESSION_DURATION_MS,
+ *                                  authSource:"forwardauth", ssoSubject, ssoUsername, provider })
+ *
+ * `durationMs` defaults to SESSION_DURATION_MS (30d) so existing callers are
+ * unaffected. The SSO bridge (Phase 4) passes SSO_SESSION_DURATION_MS (8h).
+ */
 export async function issueSession(input: {
 	userId: string;
 	userAgent?: string | null;
+	/** Defaults to SESSION_DURATION_MS (30d). Pass SSO_SESSION_DURATION_MS for SSO sessions. */
+	durationMs?: number;
+	/** Defaults to "local". Pass "forwardauth" for SSO sessions. */
+	authSource?: string;
+	/** SSO subject identifier (stable across renames). Null for local sessions. */
+	ssoSubject?: string | null;
+	/** SSO display username. Null for local sessions. */
+	ssoUsername?: string | null;
+	/** Forwardauth provider label (e.g. "authentik"). Null for local sessions. */
+	provider?: string | null;
 }): Promise<IssuedSession> {
 	const token = randomBytes(32).toString("hex");
 	const tokenHash = hashToken(token);
-	const expiresAt = new Date(Date.now() + SESSION_DURATION_MS).toISOString();
+	const durationMs = input.durationMs ?? SESSION_DURATION_MS;
+	const expiresAt = new Date(Date.now() + durationMs).toISOString();
 	const now = new Date().toISOString();
 	await getDb()
 		.insert(authSessions)
@@ -156,12 +189,28 @@ export async function issueSession(input: {
 			userAgent: input.userAgent ?? null,
 			createdAt: now,
 			lastSeenAt: now,
+			authSource: input.authSource ?? "local",
+			ssoSubject: input.ssoSubject ?? null,
+			ssoUsername: input.ssoUsername ?? null,
+			provider: input.provider ?? null,
 		});
 	return { token, tokenHash, expiresAt };
 }
 
-/** Look up a session by raw cookie token. Returns null if missing or expired. */
-export async function getUserBySessionToken(token: string): Promise<LocalUser | null> {
+/**
+ * Resolve a raw cookie token to a typed session record.
+ *
+ * Returns:
+ *   - `{ kind:"local", user }` — token belongs to a local-account session.
+ *   - `{ kind:"sso", subject, username, provider }` — token belongs to an SSO-bridged session.
+ *   - `null` — token missing, unknown, or expired (expired rows are deleted on read).
+ *
+ * This is the single step-2 chokepoint: getAuthUserFromHeaders, the WS path,
+ * and requireAuth all inherit SSO-cookie resolution through this function.
+ * Never import AuthUser here — map at the call site to avoid a circular dep
+ * with auth/middleware.ts.
+ */
+export async function resolveSessionByToken(token: string): Promise<SessionResolution | null> {
 	if (!token) return null;
 	const tokenHash = hashToken(token);
 	const [row] = await getDb()
@@ -180,7 +229,24 @@ export async function getUserBySessionToken(token: string): Promise<LocalUser | 
 		.update(authSessions)
 		.set({ lastSeenAt: now.toISOString() })
 		.where(eq(authSessions.tokenHash, tokenHash));
-	return getUserById(row.userId);
+
+	if (row.authSource === "forwardauth") {
+		// A subject-less SSO row is malformed — it would produce AuthUser.id === ""
+		// downstream, which is an invalid identity (xander L-2). Treat the row as
+		// unresolvable rather than emit a subject-less SSO identity.
+		if (!row.ssoSubject) return null;
+		return {
+			kind: "sso",
+			subject: row.ssoSubject,
+			username: row.ssoUsername ?? "",
+			provider: row.provider ?? "",
+		};
+	}
+
+	// Local session — fetch the user row (may be null if the user was deleted).
+	const user = await getUserById(row.userId);
+	if (!user) return null;
+	return { kind: "local", user };
 }
 
 export async function revokeSessionByToken(token: string): Promise<void> {

--- a/src/web/components/Layout.tsx
+++ b/src/web/components/Layout.tsx
@@ -314,7 +314,7 @@ export function Layout() {
 										{item.label}
 									</NavLink>
 								))}
-								{signOutUrl && (
+								{user && (
 									<button
 										type="button"
 										onClick={handleSignOut}

--- a/src/web/components/TopBar.tsx
+++ b/src/web/components/TopBar.tsx
@@ -154,7 +154,7 @@ function UserMenu({
 							onClick={() => setOpen(false)}
 						/>
 					)}
-					{signOutUrl && (
+					{user && (
 						<button
 							type="button"
 							onClick={handleSignOut}

--- a/src/web/hooks/useSignOut.ts
+++ b/src/web/hooks/useSignOut.ts
@@ -3,15 +3,20 @@ import { useUserStore } from "../stores/user-store.js";
 
 /**
  * Encapsulates the sign-out flow shared by Layout (mobile drawer) and
- * TopBar (desktop UserMenu). Handles both local-session logout (POST to
- * /api/…, then bounce to /login) and forwardauth IdP / external logout
- * (hard-navigate to the IdP's logout URL). The sign-out URL is provided
- * by the server at /auth/me and varies per provider — callers treat it
- * as opaque.
+ * TopBar (desktop UserMenu). Handles all three sign-out paths:
  *
- * When signOutUrl is null (non-Authentik forwardauth providers that do
- * not expose a logout endpoint) the Sign out button is hidden by the
- * caller; this hook is never invoked.
+ *   Local session (signOutUrl starts with "/api/"): POST the session-
+ *   specific logout URL, clear local user state, navigate to /login.
+ *
+ *   SSO/forwardauth session with an IdP logout URL: POST /auth/logout
+ *   first to revoke the bridged ap_session server-side, then hard-navigate
+ *   to the IdP's logout URL (e.g. Authentik's /outpost.goauthentik.io/sign_out).
+ *
+ *   SSO/forwardauth session without an IdP logout URL (non-Authentik
+ *   providers that expose no logout endpoint): POST /auth/logout to revoke
+ *   the ap_session, then clear local user state and navigate to /login.
+ *   The Sign out control is always shown to authenticated users regardless
+ *   of whether signOutUrl is set — the caller must not hide it on null.
  */
 export function useSignOut() {
 	const signOutUrl = useUserStore((s) => s.signOutUrl);
@@ -20,13 +25,26 @@ export function useSignOut() {
 
 	async function handleSignOut() {
 		if (signOutUrl?.startsWith("/api/")) {
-			// Local session: POST to our logout endpoint and bounce to /login.
+			// Local session: POST to the session-specific logout endpoint.
 			await fetch(signOutUrl, { method: "POST", credentials: "same-origin" }).catch(() => {});
 			await reloadUser();
 			navigate("/login", { replace: true });
-		} else if (signOutUrl) {
-			// External IdP logout: hard-navigate so the upstream provider handles it.
-			window.location.assign(signOutUrl);
+		} else {
+			// SSO/forwardauth session: revoke the ap_session cookie server-side first
+			// so subsequent un-forwardauth'd /auth/me calls are unauthenticated,
+			// even if the browser retains the stale cookie for a moment.
+			await fetch("/api/v1/auth/logout", {
+				method: "POST",
+				credentials: "same-origin",
+			}).catch(() => {});
+			if (signOutUrl) {
+				// IdP has a logout URL — hand off so the provider can clear its session.
+				window.location.assign(signOutUrl);
+			} else {
+				// Provider has no logout URL: just clear local state and bounce to /login.
+				await reloadUser();
+				navigate("/login", { replace: true });
+			}
 		}
 	}
 

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -302,9 +302,11 @@ export const api = {
 			body: JSON.stringify(body),
 		}),
 
-	getSupervisors: () => request<{ supervisors: SupervisorRecord[]; total: number }>("/supervisors"),
+	getSupervisors: () =>
+		request<{ supervisors: SupervisorRecord[]; total: number }>("/admin/supervisors"),
 
-	getSupervisor: (id: string) => request<{ supervisor: SupervisorRecord }>(`/supervisors/${id}`),
+	getSupervisor: (id: string) =>
+		request<{ supervisor: SupervisorRecord }>(`/admin/supervisors/${id}`),
 
 	enrollSupervisor: (body: {
 		name?: string;
@@ -324,7 +326,7 @@ export const api = {
 				usedAt: string | null;
 				revokedAt: string | null;
 			};
-		}>("/supervisors/enroll", {
+		}>("/admin/supervisors/enroll", {
 			method: "POST",
 			body: JSON.stringify(body),
 		}),
@@ -343,7 +345,7 @@ export const api = {
 				usedAt: string | null;
 				revokedAt: string | null;
 			};
-		}>(`/supervisors/${id}/rotate`, {
+		}>(`/admin/supervisors/${id}/rotate`, {
 			method: "POST",
 			body: JSON.stringify(body ?? {}),
 		}),
@@ -355,7 +357,7 @@ export const api = {
 		}),
 
 	revokeSupervisor: (id: string) =>
-		request<{ ok: true }>(`/supervisors/${id}/revoke`, {
+		request<{ ok: true }>(`/admin/supervisors/${id}/revoke`, {
 			method: "POST",
 		}),
 


### PR DESCRIPTION
## Summary

Two fixes that must ship in the same image.

### AGEN-5 — SSO completes but AgentPulse still prompts for a password
Authentik SSO was non-functional. Root causes: (1) the Traefik `agentpulse-inject-verify` middleware ships an empty `X-Authentik-Verify` placeholder (Traefik deletes empty headers → the trust gate rejects every request) — an ops/overlay gap fixed at deploy, not in code; (2) the SPA's auth-state probe couldn't see the SSO identity because the forwardauth code path never minted a session.

**Fix (preserves local-auth):** a `bridgeForwardauthSession` middleware mints an `ap_session` cookie for trust-gated forwardauth identities, so the un-forwardauth'd `/auth/me` (and WS) resolve SSO via the existing cookie path.

- **Phase 1** — additive `auth_sessions` columns (`auth_source`, `sso_subject`, `sso_username`, `provider`), both dialects + legacy SQLite init + lockstep migrations.
- **Phase 2** — extend `issueSession`; unified `resolveSessionByToken` (local|sso); **Bearer-precedence hardening**: a `Bearer ap_*` key is authoritative when present (validated before the cookie, no fallthrough on an invalid key) — closes a bypass where a fake Bearer dodged forwardauth and rode a stale cookie.
- **Phase 3** — split supervisor routes: management (enroll/rotate/revoke/list/get) moved behind forwardauth at `/api/v1/admin/supervisors/*`; machine-agent endpoints stay edge-public. Closes a path where a stale SSO cookie could mint enrollment tokens.
- **Phase 4** — the bridge middleware: resolve-then-mint (fixation-safe), fail-closed (revoke + clear cookie on mint failure), supersede-revoke of old sessions, 8h cookie (`AGENTPULSE_SSO_SESSION_DURATION_MS`), non-admin SSO identities.
- **Phase 5** — always-available SSO sign-out (server-side revoke before IdP redirect); corrected an inverted fail-closed startup warning.
- **Phase 6 + reconcile** — docs (FORWARDAUTH.md session-bridge, RUNBOOK correction, CLAUDE.md); IngressRoute exemptions for the SPA's actual base (`/app-api/v1/auth/*` + `/app-api/v1/ws`).

### AGEN-6 — watcher runner soft-locks a vCPU and kills the k8s node
`RunLeaser.drain()` looped `while(true)` awaiting only `bun:sqlite` calls (microtask-resolved), never yielding to the macrotask queue → pinned a vCPU even on a broken/0-replica pod → (amplified by split-lock traps from an unpinned `oven/bun:1`) soft-locked the guest kernel and jammed the whole node. Fix: a `setTimeout(0)` yield in the drain loop + pin the Dockerfile to `oven/bun:1.3.12`.

## Review trail
Plan reviewed by 6 lenses + 3 codex rounds (2 BLOCKs caught + resolved); each build phase gated by ian (change-impact) and xander (security); full diff passed codex r2 and a valerie plan-vs-diff signoff. **889 tests, 0 failures**; typecheck + all architecture guards green.

## Deploy (coordinated — required before scaling agentpulse back up)
1. Build the image carrying both fixes; push to the cluster registry.
2. In the private overlay: inject the real `FORWARDAUTH_TRUST_SECRET` into `agentpulse-inject-verify`; mirror the new `/app-api/v1/auth/*` + `/ws` exemptions; apply the middleware-chain hardening noted in review; bump the deployment image.
3. `kubectl diff -k` → review → apply; verify middleware value == pod secret.
4. Scale to 1; verify SSO lands on the dashboard (no password prompt), local-auth still works, and node load stays low.

## Known follow-ups (out of scope; tracked separately)
- embedding-service infinite-retry needs a backoff cap.
- supervisor unscoped-enrollment-token slot-takeover (pre-existing).
- API keys are unscoped (any valid key can manage supervisors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)