### PR TITLE
Post-SSO security & reliability follow-ups (AGEN-7/8/9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Schema is split across `src/server/db/schema/{core,ai,ask-projects}/` with per-t
 
 - `sessions` - id, session_id, display_name, agent_type, status, cwd, model, is_working, is_pinned, git_branch, notes, semantic_status, current_task, plan_summary, total_tool_uses, metadata, timestamps, is_archived. Note: `is_archived` is the canonical archive predicate; `status='archived'` is a legacy value retained for backwards-compat (see `src/shared/session-state.ts`).
 - `events` - id, session_id, event_type, tool_name, tool_input, tool_response, raw_payload, created_at
-- `api_keys` - id, name, key_hash, key_prefix, is_active, timestamps
+- `api_keys` - id, name, key_hash, key_prefix, is_active, scopes (JSON text, default `'["ingest"]'`), timestamps
 - `settings` - key, value, updated_at
 - AI control plane (always created; runtime gated by `AGENTPULSE_AI_ENABLED`):
   - `llm_providers`, `watcher_configs`, `watcher_proposals`, `ai_daily_spend`
@@ -163,6 +163,7 @@ Do NOT use or document `503 / ai_kill_switch_active` — that code and message w
   - **Session bridge** (`src/server/auth/forwardauth-bridge.ts`, AGEN-5): on the first forwardauth-gated request, mints an `ap_session` cookie (8h default; `AGENTPULSE_SSO_SESSION_DURATION_MS`) so `/auth/me` and WS upgrades resolve the SSO identity through the existing cookie step. `auth_sessions` has four additive columns: `auth_source` (text, not-null, default `"local"`), `sso_subject` (nullable), `sso_username` (nullable), `provider` (nullable). SSO sessions are non-admin (`source:"forwardauth"`, `role:null`); no shadow `users` row is created.
   - **`/auth/me` is un-forwardauth'd by design**: listed in the IngressRoute without the middleware chain. Moving it behind forwardauth would break local-auth fallback and double-set the cookie via the bridge. `Bearer ap_*` is authoritative when present — valid key → `api_key` identity; invalid/unknown key → 401 (the cookie is never consulted as fallback).
   - **Supervisor split**: dashboard-management routes at `/api/v1/admin/supervisors/*` (not in the IngressRoute exemption list; falls through to the forwardauth catch-all for live IdP revocation). Machine-agent routes remain at edge-public `/api/v1/supervisors/*` with supervisor-credential auth.
+  - **API key scopes (AGEN-9)**: every key carries an explicit capability set stored as a JSON array in `api_keys.scopes` (TEXT NOT NULL DEFAULT `'["ingest"]'`). Two recognized scopes: `ingest` (post hook events) and `manage` (supervisor enroll/rotate/revoke, API-key CRUD). The `*` wildcard is valid in DB records only (never accepted from a client request). `requireScope("manage")` is chained after `requireAuth` on the full `supervisorsAdminRouter` and the three `/api-keys` CRUD handlers. `requireApiKey` (hook path) enforces `ingest`. forwardauth / local sessions are never scope-checked — scoping applies only to `api_key` callers. Rejection: `403 { error: "insufficient_scope", required: "<scope>" }`. Default bootstrap key (`ensureDefaultApiKey`) gets `["ingest","manage"]` so fresh installs aren't locked out. Hook-setup flows (SetupPage, FirstRunWelcome) mint ingest-only keys. **Re-grant procedure**: mint a new key with the desired scopes via Settings (`POST /api/v1/api-keys` with `scopes` param), then revoke the old one — there is no scope-edit endpoint (mint-new + revoke-old is intentional). Fast-follow: `channelsRouter` gating with `manage` is deferred (noted in settings.ts).
 
 ### Relay (for remote server users)
 Claude Code blocks hooks to non-localhost IPs. The relay (`scripts/relay.ts`) runs on localhost and forwards events to the remote server. LaunchAgent auto-starts it on macOS login.
@@ -197,7 +198,9 @@ Claude Code blocks hooks to non-localhost IPs. The relay (`scripts/relay.ts`) ru
 - `PUT /api/v1/sessions/:id/claude-md` - Save CLAUDE.md content for session
 - `GET /api/v1/settings` - Get app settings
 - `PUT /api/v1/settings` - Update a setting (returns 403 `{ error: "key_not_user_settable", key }` for protected keys)
-- `GET/POST/DELETE /api/v1/api-keys` - Manage API keys
+- `GET /api/v1/api-keys` - List API keys (requires `manage` scope for api_key callers; returns `scopes: string[]` per key)
+- `POST /api/v1/api-keys` - Create API key (requires `manage` scope; accepts `{ name, scopes?: string[] }`, defaults to `["ingest"]`; rejects unknown scopes with `400 { error: "invalid_scope", value }`)
+- `DELETE /api/v1/api-keys/:id` - Revoke API key (requires `manage` scope)
 - `WS /api/v1/ws` - Real-time event stream
 
 ## Key Conventions

--- a/drizzle/postgres/0002_dark_tombstone.sql
+++ b/drizzle/postgres/0002_dark_tombstone.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "api_keys" ADD COLUMN "scopes" text DEFAULT '["ingest"]' NOT NULL;

--- a/drizzle/postgres/meta/0002_snapshot.json
+++ b/drizzle/postgres/meta/0002_snapshot.json
@@ -1,0 +1,2996 @@
+{
+	"id": "8ab9cfec-1615-426e-ae1f-dbe0fc894de2",
+	"prevId": "e9e825ed-95d5-4042-a4ba-89dc3301cbfd",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.ai_action_requests": {
+			"name": "ai_action_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'awaiting_reply'"
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"question": {
+					"name": "question",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload": {
+					"name": "payload",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ask_thread_id": {
+					"name": "ask_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resolved_at": {
+					"name": "resolved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resolved_by": {
+					"name": "resolved_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"result_event_id": {
+					"name": "result_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_daily_spend": {
+			"name": "ai_daily_spend",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"spend_cents": {
+					"name": "spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ai_daily_spend_user_id_date_pk": {
+					"name": "ai_daily_spend_user_id_date_pk",
+					"columns": ["user_id", "date"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_hitl_requests": {
+			"name": "ai_hitl_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'awaiting_reply'"
+				},
+				"reply_kind": {
+					"name": "reply_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reply_text": {
+					"name": "reply_text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_ai_hitl_requests_session_status": {
+					"name": "idx_ai_hitl_requests_session_status",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_ai_hitl_requests_open_per_session": {
+					"name": "idx_ai_hitl_requests_open_per_session",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"ai_hitl_requests\".\"status\" = 'awaiting_reply'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ai_hitl_requests_session_id_sessions_session_id_fk": {
+					"name": "ai_hitl_requests_session_id_sessions_session_id_fk",
+					"tableFrom": "ai_hitl_requests",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_inbox_snoozes": {
+			"name": "ai_inbox_snoozes",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snoozed_until": {
+					"name": "snoozed_until",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_pending_project_drafts": {
+			"name": "ai_pending_project_drafts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"ask_thread_id": {
+					"name": "ask_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'add_project'"
+				},
+				"draft_fields": {
+					"name": "draft_fields",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"next_question": {
+					"name": "next_question",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'drafting'"
+				},
+				"action_request_id": {
+					"name": "action_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_pending_project_drafts_thread": {
+					"name": "idx_pending_project_drafts_thread",
+					"columns": [
+						{
+							"expression": "ask_thread_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"ai_pending_project_drafts\".\"status\" IN ('drafting', 'pending_approval')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_qa_cache": {
+			"name": "ai_qa_cache",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"question_hash": {
+					"name": "question_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"response": {
+					"name": "response",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_event_id": {
+					"name": "last_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cached_at": {
+					"name": "cached_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"idx_qa_cache_session_question": {
+					"name": "idx_qa_cache_session_question",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "question_hash",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ai_watcher_runs": {
+			"name": "ai_watcher_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"trigger_event_id": {
+					"name": "trigger_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trigger_kind": {
+					"name": "trigger_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"dedupe_key": {
+					"name": "dedupe_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lease_owner": {
+					"name": "lease_owner",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lease_expires_at": {
+					"name": "lease_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"attempt_count": {
+					"name": "attempt_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"last_error_sub_type": {
+					"name": "last_error_sub_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_ai_watcher_runs_status_lease": {
+					"name": "idx_ai_watcher_runs_status_lease",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "lease_expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_ai_watcher_runs_session_created": {
+					"name": "idx_ai_watcher_runs_session_created",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_ai_watcher_runs_open_per_session": {
+					"name": "idx_ai_watcher_runs_open_per_session",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"ai_watcher_runs\".\"status\" IN ('queued', 'claimed', 'running')",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"ai_watcher_runs_session_id_sessions_session_id_fk": {
+					"name": "ai_watcher_runs_session_id_sessions_session_id_fk",
+					"tableFrom": "ai_watcher_runs",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_keys": {
+			"name": "api_keys",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key_hash": {
+					"name": "key_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"key_prefix": {
+					"name": "key_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"last_used_at": {
+					"name": "last_used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[\"ingest\"]'"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"api_keys_key_hash_unique": {
+					"name": "api_keys_key_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["key_hash"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ask_messages": {
+			"name": "ask_messages",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"thread_id": {
+					"name": "thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"context_session_ids": {
+					"name": "context_session_ids",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_in": {
+					"name": "tokens_in",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_out": {
+					"name": "tokens_out",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.ask_threads": {
+			"name": "ask_threads",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'web'"
+				},
+				"telegram_chat_id": {
+					"name": "telegram_chat_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_ask_threads_updated": {
+					"name": "idx_ask_threads_updated",
+					"columns": [
+						{
+							"expression": "updated_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"ask_threads\".\"archived_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"idx_ask_threads_telegram_chat": {
+					"name": "idx_ask_threads_telegram_chat",
+					"columns": [
+						{
+							"expression": "telegram_chat_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"ask_threads\".\"telegram_chat_id\" IS NOT NULL AND \"ask_threads\".\"archived_at\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.auth_sessions": {
+			"name": "auth_sessions",
+			"schema": "",
+			"columns": {
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"auth_source": {
+					"name": "auth_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'local'"
+				},
+				"sso_subject": {
+					"name": "sso_subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sso_username": {
+					"name": "sso_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.control_actions": {
+			"name": "control_actions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"launch_request_id": {
+					"name": "launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action_type": {
+					"name": "action_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"requested_by": {
+					"name": "requested_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata_json": {
+					"name": "metadata_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_by_supervisor_id": {
+					"name": "claimed_by_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"control_actions_session_id_sessions_session_id_fk": {
+					"name": "control_actions_session_id_sessions_session_id_fk",
+					"tableFrom": "control_actions",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"identity": {
+						"type": "always",
+						"name": "events_id_seq",
+						"schema": "public",
+						"increment": "1",
+						"startWith": "1",
+						"minValue": "1",
+						"maxValue": "2147483647",
+						"cache": "1",
+						"cycle": false
+					}
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'observed_hook'"
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_noise": {
+					"name": "is_noise",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"provider_event_type": {
+					"name": "provider_event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_name": {
+					"name": "tool_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_input": {
+					"name": "tool_input",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_response": {
+					"name": "tool_response",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_payload": {
+					"name": "raw_payload",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"events_session_id_sessions_session_id_fk": {
+					"name": "events_session_id_sessions_session_id_fk",
+					"tableFrom": "events",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.launch_requests": {
+			"name": "launch_requests",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"template_id": {
+					"name": "template_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"launch_correlation_id": {
+					"name": "launch_correlation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_instructions": {
+					"name": "base_instructions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"task_prompt": {
+					"name": "task_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approval_policy": {
+					"name": "approval_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sandbox_mode": {
+					"name": "sandbox_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"requested_launch_mode": {
+					"name": "requested_launch_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'interactive_terminal'"
+				},
+				"env_json": {
+					"name": "env_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::json"
+				},
+				"launch_spec_json": {
+					"name": "launch_spec_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::json"
+				},
+				"requested_by": {
+					"name": "requested_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"requested_supervisor_id": {
+					"name": "requested_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"routing_policy": {
+					"name": "routing_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resolved_supervisor_id": {
+					"name": "resolved_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"routing_decision_json": {
+					"name": "routing_decision_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claimed_by_supervisor_id": {
+					"name": "claimed_by_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claim_token": {
+					"name": "claim_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"validation_warnings_json": {
+					"name": "validation_warnings_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::json"
+				},
+				"validation_summary": {
+					"name": "validation_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatch_started_at": {
+					"name": "dispatch_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatch_finished_at": {
+					"name": "dispatch_finished_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"awaiting_session_deadline_at": {
+					"name": "awaiting_session_deadline_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pid": {
+					"name": "pid",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_launch_metadata_json": {
+					"name": "provider_launch_metadata_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retry_of_launch_request_id": {
+					"name": "retry_of_launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_session_id": {
+					"name": "parent_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"desired_display_name": {
+					"name": "desired_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"launch_requests_launch_correlation_id_unique": {
+					"name": "launch_requests_launch_correlation_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["launch_correlation_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.llm_providers": {
+			"name": "llm_providers",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'local'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_url": {
+					"name": "base_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"credential_ciphertext": {
+					"name": "credential_ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_hint": {
+					"name": "credential_hint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_default": {
+					"name": "is_default",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.managed_sessions": {
+			"name": "managed_sessions",
+			"schema": "",
+			"columns": {
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"launch_request_id": {
+					"name": "launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_session_id": {
+					"name": "provider_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_thread_id": {
+					"name": "provider_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"managed_state": {
+					"name": "managed_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"correlation_source": {
+					"name": "correlation_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"desired_thread_title": {
+					"name": "desired_thread_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_thread_title": {
+					"name": "provider_thread_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_sync_state": {
+					"name": "provider_sync_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"provider_sync_error": {
+					"name": "provider_sync_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_provider_sync_at": {
+					"name": "last_provider_sync_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_protocol_version": {
+					"name": "provider_protocol_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_capability_snapshot_json": {
+					"name": "provider_capability_snapshot_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"active_control_action_id": {
+					"name": "active_control_action_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"control_lock_expires_at": {
+					"name": "control_lock_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"host_name": {
+					"name": "host_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"host_affinity_reason": {
+					"name": "host_affinity_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"managed_sessions_session_id_sessions_session_id_fk": {
+					"name": "managed_sessions_session_id_sessions_session_id_fk",
+					"tableFrom": "managed_sessions",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.notification_channels": {
+			"name": "notification_channels",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'local'"
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_ciphertext": {
+					"name": "credential_ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"config_json": {
+					"name": "config_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"verified_at": {
+					"name": "verified_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_alert_rule_fires": {
+			"name": "project_alert_rule_fires",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"rule_id": {
+					"name": "rule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fired_at": {
+					"name": "fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_alert_rule_fires_rule_session": {
+					"name": "idx_alert_rule_fires_rule_session",
+					"columns": [
+						{
+							"expression": "rule_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.project_alert_rules": {
+			"name": "project_alert_rules",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rule_type": {
+					"name": "rule_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"daily_token_spend_cents": {
+					"name": "daily_token_spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"daily_token_spend_date": {
+					"name": "daily_token_spend_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_evaluated_event_id": {
+					"name": "last_evaluated_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_project_alert_rules_project": {
+					"name": "idx_project_alert_rules_project",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"project_alert_rules\".\"is_active\" = true",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"github_repo_url": {
+					"name": "github_repo_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_agent_type": {
+					"name": "default_agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_model": {
+					"name": "default_model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_launch_mode": {
+					"name": "default_launch_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_favorite": {
+					"name": "is_favorite",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"projects_name_unique": {
+					"name": "projects_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session_templates": {
+			"name": "session_templates",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"base_instructions": {
+					"name": "base_instructions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"task_prompt": {
+					"name": "task_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approval_policy": {
+					"name": "approval_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sandbox_mode": {
+					"name": "sandbox_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::json"
+				},
+				"tags": {
+					"name": "tags",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::json"
+				},
+				"is_favorite": {
+					"name": "is_favorite",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"template_project_overrides": {
+					"name": "template_project_overrides",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {
+				"idx_session_templates_project_id": {
+					"name": "idx_session_templates_project_id",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"where": "\"session_templates\".\"project_id\" IS NOT NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sessions": {
+			"name": "sessions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"transcript_path": {
+					"name": "transcript_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"semantic_status": {
+					"name": "semantic_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_task": {
+					"name": "current_task",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"plan_summary": {
+					"name": "plan_summary",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_tool_uses": {
+					"name": "total_tool_uses",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"is_working": {
+					"name": "is_working",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_pinned": {
+					"name": "is_pinned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"git_branch": {
+					"name": "git_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claude_md_content": {
+					"name": "claude_md_content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claude_md_path": {
+					"name": "claude_md_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claude_md_checksum": {
+					"name": "claude_md_checksum",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"claude_md_updated_at": {
+					"name": "claude_md_updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "''"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_archived": {
+					"name": "is_archived",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"watcher_state": {
+					"name": "watcher_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"watcher_last_run_at": {
+					"name": "watcher_last_run_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"watcher_last_user_prompt_at": {
+					"name": "watcher_last_user_prompt_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ai_spend_cents": {
+					"name": "ai_spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"sessions_session_id_unique": {
+					"name": "sessions_session_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["session_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.settings": {
+			"name": "settings",
+			"schema": "",
+			"columns": {
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.supervisor_credentials": {
+			"name": "supervisor_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token_prefix": {
+					"name": "token_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"last_used_at": {
+					"name": "last_used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"supervisor_credentials_supervisor_id_unique": {
+					"name": "supervisor_credentials_supervisor_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["supervisor_id"]
+				},
+				"supervisor_credentials_token_hash_unique": {
+					"name": "supervisor_credentials_token_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token_hash"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.supervisor_enrollment_tokens": {
+			"name": "supervisor_enrollment_tokens",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token_prefix": {
+					"name": "token_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"used_at": {
+					"name": "used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"supervisor_enrollment_tokens_token_hash_unique": {
+					"name": "supervisor_enrollment_tokens_token_hash_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token_hash"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.supervisors": {
+			"name": "supervisors",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"host_name": {
+					"name": "host_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform": {
+					"name": "platform",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"arch": {
+					"name": "arch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"capabilities_json": {
+					"name": "capabilities_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::json"
+				},
+				"trusted_roots_json": {
+					"name": "trusted_roots_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::json"
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'connected'"
+				},
+				"capability_schema_version": {
+					"name": "capability_schema_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"config_schema_version": {
+					"name": "config_schema_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"last_heartbeat_at": {
+					"name": "last_heartbeat_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"heartbeat_lease_expires_at": {
+					"name": "heartbeat_lease_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP + INTERVAL '90 seconds'"
+				},
+				"enrollment_state": {
+					"name": "enrollment_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.users": {
+			"name": "users",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'user'"
+				},
+				"disabled_at": {
+					"name": "disabled_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_login_at": {
+					"name": "last_login_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"users_username_unique": {
+					"name": "users_username_unique",
+					"nullsNotDistinct": false,
+					"columns": ["username"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.watcher_configs": {
+			"name": "watcher_configs",
+			"schema": "",
+			"columns": {
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"policy": {
+					"name": "policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'ask_always'"
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_continuations": {
+					"name": "max_continuations",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 10
+				},
+				"continuations_used": {
+					"name": "continuations_used",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"max_daily_cents": {
+					"name": "max_daily_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"system_prompt": {
+					"name": "system_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"watcher_configs_session_id_sessions_session_id_fk": {
+					"name": "watcher_configs_session_id_sessions_session_id_fk",
+					"tableFrom": "watcher_configs",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.watcher_proposals": {
+			"name": "watcher_proposals",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"decision": {
+					"name": "decision",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_prompt": {
+					"name": "next_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"report_summary": {
+					"name": "report_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"raw_response_json": {
+					"name": "raw_response_json",
+					"type": "json",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trigger_event_id": {
+					"name": "trigger_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_in": {
+					"name": "tokens_in",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"tokens_out": {
+					"name": "tokens_out",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"cost_cents": {
+					"name": "cost_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"usage_estimated": {
+					"name": "usage_estimated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"error_sub_type": {
+					"name": "error_sub_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "CURRENT_TIMESTAMP"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"watcher_proposals_session_id_sessions_session_id_fk": {
+					"name": "watcher_proposals_session_id_sessions_session_id_fk",
+					"tableFrom": "watcher_proposals",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/postgres/meta/_journal.json
+++ b/drizzle/postgres/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1782762924855,
 			"tag": "0001_large_agent_brand",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1782783354860,
+			"tag": "0002_dark_tombstone",
+			"breakpoints": true
 		}
 	]
 }

--- a/drizzle/sqlite/0002_natural_nova.sql
+++ b/drizzle/sqlite/0002_natural_nova.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `api_keys` ADD `scopes` text DEFAULT '["ingest"]' NOT NULL;

--- a/drizzle/sqlite/meta/0002_snapshot.json
+++ b/drizzle/sqlite/meta/0002_snapshot.json
@@ -1,0 +1,3018 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "ab9fc3f9-ccc7-4c58-8a04-f22e7057b2b0",
+	"prevId": "3a9cb62c-1512-4d69-a960-6f76f59b65b6",
+	"tables": {
+		"ai_action_requests": {
+			"name": "ai_action_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'awaiting_reply'"
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"question": {
+					"name": "question",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"payload": {
+					"name": "payload",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ask_thread_id": {
+					"name": "ask_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolved_at": {
+					"name": "resolved_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolved_by": {
+					"name": "resolved_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"result_event_id": {
+					"name": "result_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_daily_spend": {
+			"name": "ai_daily_spend",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"date": {
+					"name": "date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"spend_cents": {
+					"name": "spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"ai_daily_spend_user_id_date_pk": {
+					"columns": ["user_id", "date"],
+					"name": "ai_daily_spend_user_id_date_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_hitl_requests": {
+			"name": "ai_hitl_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'awaiting_reply'"
+				},
+				"reply_kind": {
+					"name": "reply_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reply_text": {
+					"name": "reply_text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_inbox_snoozes": {
+			"name": "ai_inbox_snoozes",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"snoozed_until": {
+					"name": "snoozed_until",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_pending_project_drafts": {
+			"name": "ai_pending_project_drafts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ask_thread_id": {
+					"name": "ask_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'add_project'"
+				},
+				"draft_fields": {
+					"name": "draft_fields",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"next_question": {
+					"name": "next_question",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'drafting'"
+				},
+				"action_request_id": {
+					"name": "action_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_qa_cache": {
+			"name": "ai_qa_cache",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"question_hash": {
+					"name": "question_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"response": {
+					"name": "response",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_event_id": {
+					"name": "last_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cached_at": {
+					"name": "cached_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_qa_cache_session_question": {
+					"name": "idx_qa_cache_session_question",
+					"columns": ["session_id", "question_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ai_watcher_runs": {
+			"name": "ai_watcher_runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"trigger_event_id": {
+					"name": "trigger_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"trigger_kind": {
+					"name": "trigger_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'queued'"
+				},
+				"dedupe_key": {
+					"name": "dedupe_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lease_owner": {
+					"name": "lease_owner",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"lease_expires_at": {
+					"name": "lease_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"attempt_count": {
+					"name": "attempt_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"last_error_sub_type": {
+					"name": "last_error_sub_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claimed_at": {
+					"name": "claimed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"proposal_id": {
+					"name": "proposal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"api_keys": {
+			"name": "api_keys",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"key_hash": {
+					"name": "key_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"key_prefix": {
+					"name": "key_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"last_used_at": {
+					"name": "last_used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[\"ingest\"]'"
+				}
+			},
+			"indexes": {
+				"api_keys_key_hash_unique": {
+					"name": "api_keys_key_hash_unique",
+					"columns": ["key_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ask_messages": {
+			"name": "ask_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"thread_id": {
+					"name": "thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"context_session_ids": {
+					"name": "context_session_ids",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_in": {
+					"name": "tokens_in",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_out": {
+					"name": "tokens_out",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"ask_threads": {
+			"name": "ask_threads",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'web'"
+				},
+				"telegram_chat_id": {
+					"name": "telegram_chat_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"archived_at": {
+					"name": "archived_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"auth_sessions": {
+			"name": "auth_sessions",
+			"columns": {
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"auth_source": {
+					"name": "auth_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'local'"
+				},
+				"sso_subject": {
+					"name": "sso_subject",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sso_username": {
+					"name": "sso_username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"control_actions": {
+			"name": "control_actions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"launch_request_id": {
+					"name": "launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"action_type": {
+					"name": "action_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"requested_by": {
+					"name": "requested_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'queued'"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata_json": {
+					"name": "metadata_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claimed_by_supervisor_id": {
+					"name": "claimed_by_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"event_embeddings": {
+			"name": "event_embeddings",
+			"columns": {
+				"event_id": {
+					"name": "event_id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"dim": {
+					"name": "dim",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"vector": {
+					"name": "vector",
+					"type": "blob",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"events": {
+			"name": "events",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'observed_hook'"
+				},
+				"content": {
+					"name": "content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_noise": {
+					"name": "is_noise",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"provider_event_type": {
+					"name": "provider_event_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tool_name": {
+					"name": "tool_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tool_input": {
+					"name": "tool_input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tool_response": {
+					"name": "tool_response",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_payload": {
+					"name": "raw_payload",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"events_session_id_sessions_session_id_fk": {
+					"name": "events_session_id_sessions_session_id_fk",
+					"tableFrom": "events",
+					"tableTo": "sessions",
+					"columnsFrom": ["session_id"],
+					"columnsTo": ["session_id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"launch_requests": {
+			"name": "launch_requests",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"template_id": {
+					"name": "template_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"launch_correlation_id": {
+					"name": "launch_correlation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_instructions": {
+					"name": "base_instructions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"task_prompt": {
+					"name": "task_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approval_policy": {
+					"name": "approval_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandbox_mode": {
+					"name": "sandbox_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"requested_launch_mode": {
+					"name": "requested_launch_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'interactive_terminal'"
+				},
+				"env_json": {
+					"name": "env_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"launch_spec_json": {
+					"name": "launch_spec_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"requested_by": {
+					"name": "requested_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"requested_supervisor_id": {
+					"name": "requested_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"routing_policy": {
+					"name": "routing_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resolved_supervisor_id": {
+					"name": "resolved_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"routing_decision_json": {
+					"name": "routing_decision_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claimed_by_supervisor_id": {
+					"name": "claimed_by_supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claim_token": {
+					"name": "claim_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'draft'"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"validation_warnings_json": {
+					"name": "validation_warnings_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"validation_summary": {
+					"name": "validation_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dispatch_started_at": {
+					"name": "dispatch_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dispatch_finished_at": {
+					"name": "dispatch_finished_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"awaiting_session_deadline_at": {
+					"name": "awaiting_session_deadline_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pid": {
+					"name": "pid",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_launch_metadata_json": {
+					"name": "provider_launch_metadata_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"retry_of_launch_request_id": {
+					"name": "retry_of_launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_session_id": {
+					"name": "parent_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"desired_display_name": {
+					"name": "desired_display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"launch_requests_launch_correlation_id_unique": {
+					"name": "launch_requests_launch_correlation_id_unique",
+					"columns": ["launch_correlation_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"llm_providers": {
+			"name": "llm_providers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'local'"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_url": {
+					"name": "base_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"credential_ciphertext": {
+					"name": "credential_ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"credential_hint": {
+					"name": "credential_hint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_default": {
+					"name": "is_default",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"managed_sessions": {
+			"name": "managed_sessions",
+			"columns": {
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"launch_request_id": {
+					"name": "launch_request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_session_id": {
+					"name": "provider_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_thread_id": {
+					"name": "provider_thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"managed_state": {
+					"name": "managed_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"correlation_source": {
+					"name": "correlation_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"desired_thread_title": {
+					"name": "desired_thread_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_thread_title": {
+					"name": "provider_thread_title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_sync_state": {
+					"name": "provider_sync_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"provider_sync_error": {
+					"name": "provider_sync_error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_provider_sync_at": {
+					"name": "last_provider_sync_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_protocol_version": {
+					"name": "provider_protocol_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_capability_snapshot_json": {
+					"name": "provider_capability_snapshot_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"active_control_action_id": {
+					"name": "active_control_action_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"control_lock_expires_at": {
+					"name": "control_lock_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"host_name": {
+					"name": "host_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"host_affinity_reason": {
+					"name": "host_affinity_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notification_channels": {
+			"name": "notification_channels",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'local'"
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"label": {
+					"name": "label",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"credential_ciphertext": {
+					"name": "credential_ciphertext",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"config_json": {
+					"name": "config_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"verified_at": {
+					"name": "verified_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"project_alert_rule_fires": {
+			"name": "project_alert_rule_fires",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rule_id": {
+					"name": "rule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"fired_at": {
+					"name": "fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"idx_alert_rule_fires_rule_session": {
+					"name": "idx_alert_rule_fires_rule_session",
+					"columns": ["rule_id", "session_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"project_alert_rules": {
+			"name": "project_alert_rules",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rule_type": {
+					"name": "rule_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"params": {
+					"name": "params",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"daily_token_spend_cents": {
+					"name": "daily_token_spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"daily_token_spend_date": {
+					"name": "daily_token_spend_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_evaluated_event_id": {
+					"name": "last_evaluated_event_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"projects": {
+			"name": "projects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"github_repo_url": {
+					"name": "github_repo_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"default_agent_type": {
+					"name": "default_agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"default_model": {
+					"name": "default_model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"default_launch_mode": {
+					"name": "default_launch_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_favorite": {
+					"name": "is_favorite",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"projects_name_unique": {
+					"name": "projects_name_unique",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session_templates": {
+			"name": "session_templates",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"base_instructions": {
+					"name": "base_instructions",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"task_prompt": {
+					"name": "task_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"approval_policy": {
+					"name": "approval_policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandbox_mode": {
+					"name": "sandbox_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"is_favorite": {
+					"name": "is_favorite",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"template_project_overrides": {
+					"name": "template_project_overrides",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"sessions": {
+			"name": "sessions",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"agent_type": {
+					"name": "agent_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"cwd": {
+					"name": "cwd",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"transcript_path": {
+					"name": "transcript_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"last_activity_at": {
+					"name": "last_activity_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"semantic_status": {
+					"name": "semantic_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"current_task": {
+					"name": "current_task",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"plan_summary": {
+					"name": "plan_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"total_tool_uses": {
+					"name": "total_tool_uses",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"is_working": {
+					"name": "is_working",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"is_pinned": {
+					"name": "is_pinned",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"git_branch": {
+					"name": "git_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claude_md_content": {
+					"name": "claude_md_content",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claude_md_path": {
+					"name": "claude_md_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claude_md_checksum": {
+					"name": "claude_md_checksum",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"claude_md_updated_at": {
+					"name": "claude_md_updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_archived": {
+					"name": "is_archived",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"watcher_state": {
+					"name": "watcher_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"watcher_last_run_at": {
+					"name": "watcher_last_run_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"watcher_last_user_prompt_at": {
+					"name": "watcher_last_user_prompt_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ai_spend_cents": {
+					"name": "ai_spend_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"sessions_session_id_unique": {
+					"name": "sessions_session_id_unique",
+					"columns": ["session_id"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"settings": {
+			"name": "settings",
+			"columns": {
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"supervisor_credentials": {
+			"name": "supervisor_credentials",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token_prefix": {
+					"name": "token_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"last_used_at": {
+					"name": "last_used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"supervisor_credentials_supervisor_id_unique": {
+					"name": "supervisor_credentials_supervisor_id_unique",
+					"columns": ["supervisor_id"],
+					"isUnique": true
+				},
+				"supervisor_credentials_token_hash_unique": {
+					"name": "supervisor_credentials_token_hash_unique",
+					"columns": ["token_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"supervisor_enrollment_tokens": {
+			"name": "supervisor_enrollment_tokens",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"supervisor_id": {
+					"name": "supervisor_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"token_hash": {
+					"name": "token_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token_prefix": {
+					"name": "token_prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"is_active": {
+					"name": "is_active",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"used_at": {
+					"name": "used_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"revoked_at": {
+					"name": "revoked_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"supervisor_enrollment_tokens_token_hash_unique": {
+					"name": "supervisor_enrollment_tokens_token_hash_unique",
+					"columns": ["token_hash"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"supervisors": {
+			"name": "supervisors",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"host_name": {
+					"name": "host_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"platform": {
+					"name": "platform",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"arch": {
+					"name": "arch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"version": {
+					"name": "version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"capabilities_json": {
+					"name": "capabilities_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'{}'"
+				},
+				"trusted_roots_json": {
+					"name": "trusted_roots_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'[]'"
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'connected'"
+				},
+				"capability_schema_version": {
+					"name": "capability_schema_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"config_schema_version": {
+					"name": "config_schema_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 1
+				},
+				"last_heartbeat_at": {
+					"name": "last_heartbeat_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"heartbeat_lease_expires_at": {
+					"name": "heartbeat_lease_expires_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now', '+90 seconds'))"
+				},
+				"enrollment_state": {
+					"name": "enrollment_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'active'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"username": {
+					"name": "username",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"password_hash": {
+					"name": "password_hash",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'user'"
+				},
+				"disabled_at": {
+					"name": "disabled_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_login_at": {
+					"name": "last_login_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {
+				"users_username_unique": {
+					"name": "users_username_unique",
+					"columns": ["username"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"watcher_configs": {
+			"name": "watcher_configs",
+			"columns": {
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"enabled": {
+					"name": "enabled",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"policy": {
+					"name": "policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'ask_always'"
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"max_continuations": {
+					"name": "max_continuations",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 10
+				},
+				"continuations_used": {
+					"name": "continuations_used",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"max_daily_cents": {
+					"name": "max_daily_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"system_prompt": {
+					"name": "system_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"watcher_proposals": {
+			"name": "watcher_proposals",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'pending'"
+				},
+				"decision": {
+					"name": "decision",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"next_prompt": {
+					"name": "next_prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"report_summary": {
+					"name": "report_summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"raw_response_json": {
+					"name": "raw_response_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"trigger_event_id": {
+					"name": "trigger_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_in": {
+					"name": "tokens_in",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"tokens_out": {
+					"name": "tokens_out",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"cost_cents": {
+					"name": "cost_cents",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"usage_estimated": {
+					"name": "usage_estimated",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"error_sub_type": {
+					"name": "error_sub_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(datetime('now'))"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/drizzle/sqlite/meta/_journal.json
+++ b/drizzle/sqlite/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1782762916771,
 			"tag": "0001_true_misty_knight",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "6",
+			"when": 1782783352154,
+			"tag": "0002_natural_nova",
+			"breakpoints": true
 		}
 	]
 }

--- a/scripts/setup-relay.sh
+++ b/scripts/setup-relay.sh
@@ -16,6 +16,17 @@ set -euo pipefail
 #  Usage:
 #    bash setup-relay.sh --url https://agentpulse.example.com --key ap_xxx
 #    bash setup-relay.sh --url https://agentpulse.example.com --key ap_xxx --port 4000
+#
+#  API key scope requirement:
+#    The relay reads and writes session data (session list, CLAUDE.md sync,
+#    Codex thread-name sync) in addition to posting hooks. The key you pass
+#    via --key must have BOTH "ingest" and "manage" scopes. In the
+#    AgentPulse Settings → API Keys UI, check both "Hook ingest" and
+#    "Dashboard management" when creating the relay key.
+#
+#    Ingest-only keys will be accepted for hook posting but will receive
+#    403 Forbidden on session reads/writes, causing sync features to silently
+#    degrade. The relay will continue forwarding hooks successfully.
 # ───────────────────────────────────────────────────────
 
 REMOTE_URL=""

--- a/src/server/app.integration.test.ts
+++ b/src/server/app.integration.test.ts
@@ -139,16 +139,16 @@ describe("M-2c — admin enroll: live forwardauth headers → 201", () => {
 	});
 });
 
-// ─── M-2d: Valid ap_ API key → 201 ──────────────────────────────────────────
+// ─── M-2d: manage-scoped ap_ API key → 201; ingest-only → 403 ──────────────
 
-describe("M-2d — admin enroll: valid ap_ API key → 201", () => {
-	test("valid ap_ Bearer key resolves as api_key source → requireAuth passes → 201", async () => {
-		const { key: apiKey } = await createApiKey("app-int-test-key");
+describe("M-2d — admin enroll: manage-scoped ap_ API key → 201", () => {
+	test("manage-scoped Bearer key → requireScope(manage) passes → 201 enrollment token", async () => {
+		const { key: manageKey } = await createApiKey("app-int-manage-key", ["ingest", "manage"]);
 
 		const res = await app.request("/api/v1/admin/supervisors/enroll", {
 			method: "POST",
 			headers: new Headers({
-				Authorization: `Bearer ${apiKey}`,
+				Authorization: `Bearer ${manageKey}`,
 				"Content-Type": "application/json",
 			}),
 			body: JSON.stringify({ name: "api-key-supervisor-m2d" }),
@@ -157,6 +157,265 @@ describe("M-2d — admin enroll: valid ap_ API key → 201", () => {
 		expect(res.status).toBe(201);
 		const body = (await res.json()) as { token: string };
 		expect(typeof body.token).toBe("string");
+	});
+});
+
+// ─── AGEN-9: Scope enforcement tests ─────────────────────────────────────────
+
+describe("AGEN-9 — scope enforcement: ingest-only key → 403 on management routes", () => {
+	test("ingest-only key → POST /api/v1/admin/supervisors/enroll → 403 insufficient_scope", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-ingest-key", ["ingest"]);
+
+		const res = await app.request("/api/v1/admin/supervisors/enroll", {
+			method: "POST",
+			headers: new Headers({
+				Authorization: `Bearer ${ingestKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ name: "should-fail" }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string; required: string };
+		expect(body.error).toBe("insufficient_scope");
+		expect(body.required).toBe("manage");
+	});
+
+	test("ingest-only key → POST /api/v1/api-keys → 403 insufficient_scope", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-ingest-for-crud", ["ingest"]);
+
+		const res = await app.request("/api/v1/api-keys", {
+			method: "POST",
+			headers: new Headers({
+				Authorization: `Bearer ${ingestKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ name: "should-also-fail" }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("insufficient_scope");
+	});
+});
+
+describe("AGEN-9 — scope enforcement: forwardauth session passes manage gate", () => {
+	test("forwardauth headers → POST /api/v1/admin/supervisors/enroll → 201 (not blocked by scope gate)", async () => {
+		const h = forwardauthHeaders({ "Content-Type": "application/json" });
+		const res = await app.request("/api/v1/admin/supervisors/enroll", {
+			method: "POST",
+			headers: h,
+			body: JSON.stringify({ name: "fa-supervisor-scope-test" }),
+		});
+
+		expect(res.status).toBe(201);
+	});
+});
+
+describe("AGEN-9 — scope enforcement: ingest key can POST hooks; manage-only key cannot", () => {
+	test("ingest-scoped key → POST /api/v1/hooks → hook accepted (200 or rate-limited)", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-hooks-ingest", ["ingest"]);
+
+		const res = await app.request("/api/v1/hooks", {
+			method: "POST",
+			headers: new Headers({
+				Authorization: `Bearer ${ingestKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ type: "SessionStart", session_id: "test-session-scope" }),
+		});
+
+		// Hook endpoint always returns 200 (always-200 contract); any 4xx is a bug.
+		expect(res.status).toBe(200);
+	});
+
+	test("manage-only key (no ingest) → POST /api/v1/hooks → 403 insufficient_scope", async () => {
+		const { key: manageOnlyKey } = await createApiKey("app-int-hooks-manage-only", ["manage"]);
+
+		const res = await app.request("/api/v1/hooks", {
+			method: "POST",
+			headers: new Headers({
+				Authorization: `Bearer ${manageOnlyKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ type: "SessionStart", session_id: "test-session-scope-2" }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string; required: string };
+		expect(body.error).toBe("insufficient_scope");
+		expect(body.required).toBe("ingest");
+	});
+});
+
+describe("AGEN-9 — scope enforcement: fake-Bearer + cookie regression", () => {
+	test("Bearer ap_invalid + valid SSO cookie → 401 (bearer is authoritative; scoping did not regress this)", async () => {
+		const { token: ssoToken } = await issueSession({
+			userId: "sso:scope-regression-subject",
+			durationMs: SSO_SESSION_DURATION_MS,
+			authSource: "forwardauth",
+			ssoSubject: "scope-regression-subject",
+			ssoUsername: TEST_USERNAME,
+			provider: TEST_PROVIDER,
+		});
+
+		const res = await app.request("/api/v1/admin/supervisors/enroll", {
+			method: "POST",
+			headers: new Headers({
+				Cookie: `${SESSION_COOKIE_NAME}=${ssoToken}`,
+				Authorization: "Bearer ap_completelyboguskey0000000000",
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ name: "scope-regression-test" }),
+		});
+
+		expect(res.status).toBe(401);
+	});
+});
+
+// ─── AGEN-9 extension: coherent scope enforcement across all dashboard routers ─
+
+describe("AGEN-9 extension — C-1/C-2: ingest key → 403 on AI control-plane routes", () => {
+	test("ingest-only key → POST /api/v1/ai/proposals/:id/decision → 403 insufficient_scope", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-c1-ingest", ["ingest"]);
+
+		const res = await app.request("/api/v1/ai/proposals/fake-id/decision", {
+			method: "POST",
+			headers: new Headers({
+				Authorization: `Bearer ${ingestKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ decision: "approve" }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("insufficient_scope");
+	});
+
+	test("ingest-only key → PUT /api/v1/ai/sessions/:id/watcher → 403 insufficient_scope", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-c2-ingest", ["ingest"]);
+
+		const res = await app.request("/api/v1/ai/sessions/fake-session/watcher", {
+			method: "PUT",
+			headers: new Headers({
+				Authorization: `Bearer ${ingestKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ enabled: true }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("insufficient_scope");
+	});
+
+	test("manage+ingest key → AI route → passes scope gate (may 404 on fake id)", async () => {
+		const { key: manageKey } = await createApiKey("app-int-c1-manage", ["ingest", "manage"]);
+
+		const res = await app.request("/api/v1/ai/proposals/fake-id/decision", {
+			method: "POST",
+			headers: new Headers({
+				Authorization: `Bearer ${manageKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ decision: "approve" }),
+		});
+
+		// Not 403 (scope gate passed); may be 404/409/501 if AI is disabled in test env.
+		expect(res.status).not.toBe(403);
+	});
+});
+
+describe("AGEN-9 extension — H-1/H-2: ingest key → 403 on settings routes", () => {
+	test("ingest-only key → GET /api/v1/settings → 403 insufficient_scope", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-h2-settings-get", ["ingest"]);
+
+		const res = await app.request("/api/v1/settings", {
+			headers: new Headers({ Authorization: `Bearer ${ingestKey}` }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("insufficient_scope");
+	});
+
+	test("ingest-only key → PUT /api/v1/settings/workspace → 403 insufficient_scope", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-h1-workspace", ["ingest"]);
+
+		const res = await app.request("/api/v1/settings/workspace", {
+			method: "PUT",
+			headers: new Headers({
+				Authorization: `Bearer ${ingestKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ workspace: { templateClaudeMd: "injected" } }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("insufficient_scope");
+	});
+});
+
+describe("AGEN-9 extension — M-1: ingest key → 403 on channels routes", () => {
+	test("ingest-only key → POST /api/v1/channels/telegram/credentials → 403 insufficient_scope", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-m1-channels", ["ingest"]);
+
+		const res = await app.request("/api/v1/channels/telegram/credentials", {
+			method: "POST",
+			headers: new Headers({
+				Authorization: `Bearer ${ingestKey}`,
+				"Content-Type": "application/json",
+			}),
+			body: JSON.stringify({ botToken: "injected-token" }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("insufficient_scope");
+	});
+});
+
+describe("AGEN-9 extension — sessions/search: ingest key → 403 on dashboard routes", () => {
+	test("ingest-only key → GET /api/v1/sessions → 403 insufficient_scope", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-sessions-ingest", ["ingest"]);
+
+		const res = await app.request("/api/v1/sessions", {
+			headers: new Headers({ Authorization: `Bearer ${ingestKey}` }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("insufficient_scope");
+	});
+
+	test("ingest-only key → GET /api/v1/search → 403 insufficient_scope", async () => {
+		const { key: ingestKey } = await createApiKey("app-int-search-ingest", ["ingest"]);
+
+		const res = await app.request("/api/v1/search?q=test", {
+			headers: new Headers({ Authorization: `Bearer ${ingestKey}` }),
+		});
+
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("insufficient_scope");
+	});
+
+	test("manage+ingest key → GET /api/v1/sessions → 200 (scope gate passes)", async () => {
+		const { key: manageKey } = await createApiKey("app-int-sessions-manage", ["ingest", "manage"]);
+
+		const res = await app.request("/api/v1/sessions", {
+			headers: new Headers({ Authorization: `Bearer ${manageKey}` }),
+		});
+
+		expect(res.status).toBe(200);
+	});
+
+	test("forwardauth → GET /api/v1/sessions → 200 (scope gate transparent to human users)", async () => {
+		const h = forwardauthHeaders();
+		const res = await app.request("/api/v1/sessions", { headers: h });
+		expect(res.status).toBe(200);
 	});
 });
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -23,7 +23,7 @@ import { join } from "node:path";
 import { Hono } from "hono";
 import { logger } from "hono/logger";
 import { bridgeForwardauthSession } from "./auth/forwardauth-bridge.js";
-import { requireAuth } from "./auth/middleware.js";
+import { requireAuth, requireScope } from "./auth/middleware.js";
 import { config } from "./config.js";
 import { securityHeaders } from "./middleware/security-headers.js";
 import aiInboxRouter from "./routes/ai-inbox.js";
@@ -84,6 +84,9 @@ api.route("/v1", launchesRouter);
 // pre-split shape where aiRouter had a single use("*", requireAuth()).
 const aiRouter = new Hono();
 aiRouter.use("*", requireAuth());
+// All AI control-plane routes are operator-only; ingest-scoped api_keys must
+// not reach proposals, watcher config, or any other AI surface (C-1, C-2).
+aiRouter.use("*", requireScope("manage"));
 aiRouter.route("/", aiStatusRouter);
 aiRouter.route("/", aiProvidersRouter);
 aiRouter.route("/", aiWatcherRouter);

--- a/src/server/auth/api-key.test.ts
+++ b/src/server/auth/api-key.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the scope model in src/server/auth/api-key.ts (AGEN-9).
+ *
+ * Tests cover:
+ *  - parseScopes: valid JSON, malformed JSON, non-array, empty string → fail-closed to ["ingest"]
+ *  - createApiKey: rejects unknown scope values (InvalidScopeError)
+ *  - createApiKey: accepts recognized scope values and defaults to ["ingest"]
+ *  - verifyApiKey: returns parsed scopes from the DB record
+ */
+
+import { describe, expect, test } from "bun:test";
+
+// Bootstrap the test DB before any db-touching import.
+import "../db/__test_db.js";
+
+const { parseScopes, InvalidScopeError, createApiKey, verifyApiKey, SCOPE_INGEST, SCOPE_MANAGE } =
+	await import("./api-key.js");
+
+// ── parseScopes ───────────────────────────────────────────────────────────────
+
+describe("parseScopes — JSON parsing and fail-closed fallback", () => {
+	test("valid JSON array of strings → returned as-is", () => {
+		expect(parseScopes('["ingest"]')).toEqual(["ingest"]);
+		expect(parseScopes('["ingest","manage"]')).toEqual(["ingest", "manage"]);
+		expect(parseScopes('["*"]')).toEqual(["*"]);
+	});
+
+	test('null/undefined/empty string → fail-closed to ["ingest"]', () => {
+		expect(parseScopes(null)).toEqual([SCOPE_INGEST]);
+		expect(parseScopes(undefined)).toEqual([SCOPE_INGEST]);
+		expect(parseScopes("")).toEqual([SCOPE_INGEST]);
+	});
+
+	test('malformed JSON → fail-closed to ["ingest"]', () => {
+		expect(parseScopes("not json")).toEqual([SCOPE_INGEST]);
+		expect(parseScopes("{manage}")).toEqual([SCOPE_INGEST]);
+		expect(parseScopes("[")).toEqual([SCOPE_INGEST]);
+	});
+
+	test('valid JSON but non-array → fail-closed to ["ingest"]', () => {
+		expect(parseScopes('"ingest"')).toEqual([SCOPE_INGEST]);
+		expect(parseScopes("42")).toEqual([SCOPE_INGEST]);
+		expect(parseScopes('{"scope":"ingest"}')).toEqual([SCOPE_INGEST]);
+	});
+
+	test('array with non-string elements → fail-closed to ["ingest"]', () => {
+		expect(parseScopes("[1,2]")).toEqual([SCOPE_INGEST]);
+		expect(parseScopes('["ingest",null]')).toEqual([SCOPE_INGEST]);
+	});
+});
+
+// ── createApiKey scope validation ─────────────────────────────────────────────
+
+describe("createApiKey — scope validation at mint time", () => {
+	test("unknown scope value → throws InvalidScopeError", async () => {
+		let threw = false;
+		try {
+			await createApiKey("bad-scope-key", ["unknown_scope"]);
+		} catch (err) {
+			threw = true;
+			expect(err instanceof InvalidScopeError).toBe(true);
+		}
+		expect(threw).toBe(true);
+	});
+
+	test("InvalidScopeError carries the bad value", async () => {
+		try {
+			await createApiKey("bad-scope-key-2", ["launch"]);
+			throw new Error("Expected InvalidScopeError to be thrown");
+		} catch (err) {
+			expect(err instanceof InvalidScopeError).toBe(true);
+			expect((err as InstanceType<typeof InvalidScopeError>).value).toBe("launch");
+		}
+	});
+
+	test("recognized scope values are accepted", async () => {
+		// These should not throw.
+		const { key: key1 } = await createApiKey("ingest-only-test", [SCOPE_INGEST]);
+		expect(key1).toMatch(/^ap_/);
+
+		const { key: key2 } = await createApiKey("manage-only-test", [SCOPE_MANAGE]);
+		expect(key2).toMatch(/^ap_/);
+
+		const { key: key3 } = await createApiKey("both-scopes-test", [SCOPE_INGEST, SCOPE_MANAGE]);
+		expect(key3).toMatch(/^ap_/);
+	});
+
+	test('default scopes = ["ingest"] when none supplied', async () => {
+		const { key, id } = await createApiKey("default-scope-test");
+		expect(key).toMatch(/^ap_/);
+		expect(id).toBeTruthy();
+
+		// Verify the stored key has ingest scope
+		const record = await verifyApiKey(key);
+		expect(record).not.toBeNull();
+		expect(record?.scopes).toEqual([SCOPE_INGEST]);
+	});
+});
+
+// ── verifyApiKey — scopes from DB record ──────────────────────────────────────
+
+describe("verifyApiKey — scopes parsed from stored record", () => {
+	test('ingest-only key returns scopes: ["ingest"]', async () => {
+		const { key } = await createApiKey("verify-ingest-test", ["ingest"]);
+		const record = await verifyApiKey(key);
+		expect(record).not.toBeNull();
+		expect(record?.scopes).toEqual(["ingest"]);
+	});
+
+	test('manage key returns scopes: ["ingest","manage"]', async () => {
+		const { key } = await createApiKey("verify-manage-test", ["ingest", "manage"]);
+		const record = await verifyApiKey(key);
+		expect(record).not.toBeNull();
+		expect(record?.scopes).toEqual(["ingest", "manage"]);
+	});
+
+	test("invalid key → null", async () => {
+		const result = await verifyApiKey("ap_notarealkey00000000000000000000");
+		expect(result).toBeNull();
+	});
+});

--- a/src/server/auth/api-key.ts
+++ b/src/server/auth/api-key.ts
@@ -2,6 +2,56 @@ import { eq } from "drizzle-orm";
 import { getDb } from "../db/client.js";
 import { apiKeys } from "../db/schema/index.js";
 
+// ── Scope constants ───────────────────────────────────────────────────────────
+
+/** Authorizes posting hook events from Claude Code / Codex. */
+export const SCOPE_INGEST = "ingest";
+/** Authorizes management operations: supervisor enroll/rotate/revoke, API-key CRUD. */
+export const SCOPE_MANAGE = "manage";
+/** Wildcard — all scopes. Only valid when stored in the DB (never accepted from a client request). */
+export const SCOPE_ALL = "*";
+
+const RECOGNIZED_SCOPES = new Set([SCOPE_INGEST, SCOPE_MANAGE]);
+
+// ── Scope utilities ───────────────────────────────────────────────────────────
+
+/**
+ * Parse a JSON-encoded scopes string from the database.
+ * Fails closed to ["ingest"] on any error (malformed JSON, non-array, non-string elements).
+ */
+export function parseScopes(raw?: string | null): string[] {
+	try {
+		const parsed = JSON.parse(raw ?? "");
+		if (Array.isArray(parsed) && parsed.every((s) => typeof s === "string" && s.length > 0)) {
+			return parsed;
+		}
+	} catch {
+		// fall through
+	}
+	return [SCOPE_INGEST];
+}
+
+/** Typed error thrown when an unknown scope value is supplied at key-mint time. */
+export class InvalidScopeError extends Error {
+	readonly value: string;
+	constructor(value: string) {
+		super(`Unknown scope: "${value}". Recognized values: ${[...RECOGNIZED_SCOPES].join(", ")}`);
+		this.name = "InvalidScopeError";
+		this.value = value;
+	}
+}
+
+/** Validate scope values at mint time. Throws InvalidScopeError on any unknown value. */
+function validateScopes(scopes: string[]): void {
+	for (const s of scopes) {
+		if (!RECOGNIZED_SCOPES.has(s)) {
+			throw new InvalidScopeError(s);
+		}
+	}
+}
+
+// ── Key generation ────────────────────────────────────────────────────────────
+
 // Generate a new API key: ap_<32 random hex chars>
 export function generateApiKey(): string {
 	const bytes = new Uint8Array(16);
@@ -22,8 +72,19 @@ async function hashKey(key: string): Promise<string> {
 		.join("");
 }
 
-// Create a new API key and store its hash
-export async function createApiKey(name: string): Promise<{ key: string; id: string }> {
+// ── CRUD ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Create a new API key and store its hash.
+ * @param name   Human-readable label for the key.
+ * @param scopes Capability set. Defaults to ["ingest"]. Rejects unknown values.
+ */
+export async function createApiKey(
+	name: string,
+	scopes: string[] = [SCOPE_INGEST],
+): Promise<{ key: string; id: string }> {
+	validateScopes(scopes);
+
 	const key = generateApiKey();
 	const keyHash = await hashKey(key);
 	const keyPrefix = key.slice(0, 11); // "ap_" + first 8 hex chars
@@ -34,14 +95,20 @@ export async function createApiKey(name: string): Promise<{ key: string; id: str
 			name,
 			keyHash,
 			keyPrefix,
+			scopes: JSON.stringify(scopes),
 		})
 		.returning();
 
 	return { key, id: record.id };
 }
 
-// Verify an API key and return the key record if valid
-export async function verifyApiKey(key: string): Promise<{ id: string; name: string } | null> {
+/**
+ * Verify an API key and return the key record if valid.
+ * Returns scopes parsed from the DB record (not from the request).
+ */
+export async function verifyApiKey(
+	key: string,
+): Promise<{ id: string; name: string; scopes: string[] } | null> {
 	if (!key || !key.startsWith("ap_")) {
 		return null;
 	}
@@ -65,17 +132,20 @@ export async function verifyApiKey(key: string): Promise<{ id: string; name: str
 		.execute()
 		.catch(() => {});
 
-	return { id: record.id, name: record.name };
+	return { id: record.id, name: record.name, scopes: parseScopes(record.scopes) };
 }
 
-// Ensure at least one API key exists (for initial setup)
+/**
+ * Ensure at least one API key exists (for initial setup).
+ * The bootstrap key gets ["ingest","manage"] so a fresh operator can manage supervisors.
+ */
 export async function ensureDefaultApiKey(): Promise<string | null> {
 	const existing = await getDb().select().from(apiKeys).limit(1);
 	if (existing.length > 0) {
 		return null; // Already has keys
 	}
 
-	const { key } = await createApiKey("default");
+	const { key } = await createApiKey("default", [SCOPE_INGEST, SCOPE_MANAGE]);
 	console.log(`[auth] Created default API key: ${key}`);
 	console.log("[auth] Save this key -- it won't be shown again.");
 	return key;

--- a/src/server/auth/middleware.ts
+++ b/src/server/auth/middleware.ts
@@ -2,7 +2,7 @@ import { timingSafeEqual } from "node:crypto";
 import type { Context, Next } from "hono";
 import { config } from "../config.js";
 import { SESSION_COOKIE_NAME, resolveSessionByToken } from "../services/local-auth-service.js";
-import { verifyApiKey } from "./api-key.js";
+import { SCOPE_ALL, SCOPE_INGEST, verifyApiKey } from "./api-key.js";
 import { extractSupervisorToken, verifySupervisorCredential } from "./supervisor-auth.js";
 
 export interface AuthUser {
@@ -12,6 +12,12 @@ export interface AuthUser {
 	name: string;
 	id?: string;
 	role?: "user" | "admin";
+	/**
+	 * Capability set for api_key callers. Parsed from the DB record (trusted; never client-supplied).
+	 * forwardauth and local callers omit this field — they pass requireScope() unconditionally.
+	 * DISABLE_AUTH callers receive ["*"] so all gates open.
+	 */
+	scopes?: string[];
 }
 
 function parseCookieHeader(cookieHeader: string | null, name: string): string | null {
@@ -55,7 +61,7 @@ export function verifyForwardauthSecret(provided: string): boolean {
 
 export async function getAuthUserFromHeaders(headers: Headers): Promise<AuthUser | null> {
 	if (config.disableAuth) {
-		return { source: "api_key", name: "anonymous", id: "anonymous" };
+		return { source: "api_key", name: "anonymous", id: "anonymous", scopes: [SCOPE_ALL] };
 	}
 
 	// 1. Forwardauth identity headers — validated via shared-secret trust gate.
@@ -99,7 +105,9 @@ export async function getAuthUserFromHeaders(headers: Headers): Promise<AuthUser
 	const authHeader = headers.get("Authorization");
 	if (authHeader?.startsWith("Bearer ap_")) {
 		const keyRecord = await verifyApiKey(authHeader.slice(7));
-		return keyRecord ? { source: "api_key", name: keyRecord.name, id: keyRecord.id } : null;
+		return keyRecord
+			? { source: "api_key", name: keyRecord.name, id: keyRecord.id, scopes: keyRecord.scopes }
+			: null;
 	}
 
 	// 3. Session cookie (ap_session) — local or SSO-bridged (Phase 2).
@@ -138,12 +146,18 @@ export async function getAuthUser(c: Context): Promise<AuthUser | null> {
 	return getAuthUserFromHeaders(c.req.raw.headers);
 }
 
-// Middleware: require API key auth (for hook endpoints)
-// Skipped entirely when DISABLE_AUTH=true
+// Middleware: require API key auth (for hook endpoints).
+// Enforces the `ingest` scope — a manage-only key cannot post hooks.
+// Skipped entirely when DISABLE_AUTH=true.
 export function requireApiKey() {
 	return async (c: Context, next: Next) => {
 		if (config.disableAuth) {
-			c.set("authUser", { source: "api_key", name: "anonymous", id: "anonymous" });
+			c.set("authUser", {
+				source: "api_key",
+				name: "anonymous",
+				id: "anonymous",
+				scopes: [SCOPE_ALL],
+			});
 			return next();
 		}
 
@@ -158,7 +172,18 @@ export function requireApiKey() {
 			return c.json({ error: "Invalid API key" }, 401);
 		}
 
-		c.set("authUser", { source: "api_key", name: keyRecord.name, id: keyRecord.id });
+		// Enforce ingest scope at the hook boundary.
+		// Sits before hookRateLimit's always-200 zone — see ingest.ts:112.
+		if (!keyRecord.scopes.includes(SCOPE_ALL) && !keyRecord.scopes.includes(SCOPE_INGEST)) {
+			return c.json({ error: "insufficient_scope", required: SCOPE_INGEST }, 403);
+		}
+
+		c.set("authUser", {
+			source: "api_key",
+			name: keyRecord.name,
+			id: keyRecord.id,
+			scopes: keyRecord.scopes,
+		});
 		await next();
 	};
 }
@@ -168,7 +193,12 @@ export function requireApiKey() {
 export function requireAuth() {
 	return async (c: Context, next: Next) => {
 		if (config.disableAuth) {
-			c.set("authUser", { source: "api_key", name: "anonymous", id: "anonymous" });
+			c.set("authUser", {
+				source: "api_key",
+				name: "anonymous",
+				id: "anonymous",
+				scopes: [SCOPE_ALL],
+			});
 			return next();
 		}
 
@@ -181,10 +211,49 @@ export function requireAuth() {
 	};
 }
 
+/**
+ * Middleware: require a specific scope on API key callers.
+ * - DISABLE_AUTH=true → always passes.
+ * - forwardauth / local session callers → always pass (scoping only applies to api_key tokens).
+ * - api_key callers → pass when scopes includes the required scope or SCOPE_ALL ("*").
+ *   Otherwise: 403 { error: "insufficient_scope", required: scope }.
+ *
+ * Must be chained AFTER requireAuth() so authUser is already set in context.
+ */
+export function requireScope(scope: string) {
+	return async (c: Context, next: Next) => {
+		if (config.disableAuth) {
+			return next();
+		}
+
+		const authUser = c.get("authUser") as AuthUser | undefined;
+		if (!authUser) {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+
+		// Non-api_key callers (forwardauth / local) are never scope-limited.
+		if (authUser.source !== "api_key") {
+			return next();
+		}
+
+		const scopes = authUser.scopes ?? [];
+		if (scopes.includes(SCOPE_ALL) || scopes.includes(scope)) {
+			return next();
+		}
+
+		return c.json({ error: "insufficient_scope", required: scope }, 403);
+	};
+}
+
 export function requireSupervisorAuth() {
 	return async (c: Context, next: Next) => {
 		if (config.disableAuth) {
-			c.set("authUser", { source: "api_key", name: "anonymous", id: "anonymous" });
+			c.set("authUser", {
+				source: "api_key",
+				name: "anonymous",
+				id: "anonymous",
+				scopes: [SCOPE_ALL],
+			});
 			return next();
 		}
 

--- a/src/server/db/client.ts
+++ b/src/server/db/client.ts
@@ -498,7 +498,8 @@ async function runLegacySqliteInit(sqlite: Database): Promise<void> {
 			key_prefix TEXT NOT NULL,
 			is_active INTEGER NOT NULL DEFAULT 1,
 			created_at TEXT NOT NULL DEFAULT (datetime('now')),
-			last_used_at TEXT
+			last_used_at TEXT,
+			scopes TEXT NOT NULL DEFAULT '["ingest"]'
 		);
 
 		CREATE TABLE IF NOT EXISTS settings (
@@ -1024,6 +1025,9 @@ async function runLegacySqliteInit(sqlite: Database): Promise<void> {
 		"ALTER TABLE auth_sessions ADD COLUMN sso_subject TEXT",
 		"ALTER TABLE auth_sessions ADD COLUMN sso_username TEXT",
 		"ALTER TABLE auth_sessions ADD COLUMN provider TEXT",
+		// AGEN-9: API key scopes. DEFAULT '["ingest"]' backfills all existing rows
+		// to ingest-only, closing the supervisor-management escalation hole.
+		"ALTER TABLE api_keys ADD COLUMN scopes TEXT NOT NULL DEFAULT '[\"ingest\"]'",
 	];
 
 	// Vector search opt-in. The embeddings table only materializes when

--- a/src/server/db/migrations.test.ts
+++ b/src/server/db/migrations.test.ts
@@ -63,6 +63,9 @@ function getColumnNames(db: Database, tableName: string): string[] {
 /** The 4 SSO identity columns added in Phase 1. */
 const SSO_COLUMNS = ["auth_source", "sso_subject", "sso_username", "provider"] as const;
 
+/** The api_keys.scopes column added in AGEN-9. */
+const SCOPES_COLUMN = "scopes";
+
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 describeSqliteOnly("initializeDatabase boot routing — SQLite", () => {
@@ -199,6 +202,13 @@ describeSqliteOnly("initializeDatabase boot routing — SQLite", () => {
 				).toContain(col);
 			}
 
+			// AGEN-9: api_keys.scopes column must be present after fresh Drizzle migrate.
+			const apiKeyCols = getColumnNames(freshDb, "api_keys");
+			expect(
+				apiKeyCols,
+				`expected column "${SCOPES_COLUMN}" on api_keys after fresh Drizzle migrate`,
+			).toContain(SCOPES_COLUMN);
+
 			freshDb.close();
 		} finally {
 			if (originalSqlitePath === undefined) {
@@ -329,6 +339,64 @@ describeSqliteOnly("initializeDatabase boot routing — SQLite", () => {
 				col,
 			);
 		}
+
+		db.close();
+	});
+
+	test("existing install (legacy path): api_keys.scopes column added and existing rows get '[\"ingest\"]' default (AGEN-9)", async () => {
+		// Simulate a pre-existing install: sessions table present (triggers legacy path),
+		// and a pre-AGEN-9 api_keys table with an existing row (no scopes column).
+		const db = new Database(":memory:");
+		db.exec("PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;");
+		db.exec(`
+			CREATE TABLE sessions (
+				id TEXT PRIMARY KEY,
+				session_id TEXT NOT NULL UNIQUE,
+				agent_type TEXT NOT NULL,
+				status TEXT NOT NULL DEFAULT 'active',
+				started_at TEXT NOT NULL DEFAULT (datetime('now')),
+				last_activity_at TEXT NOT NULL DEFAULT (datetime('now')),
+				total_tool_uses INTEGER NOT NULL DEFAULT 0,
+				metadata TEXT DEFAULT '{}'
+			);
+			CREATE TABLE api_keys (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				key_hash TEXT NOT NULL UNIQUE,
+				key_prefix TEXT NOT NULL,
+				is_active INTEGER NOT NULL DEFAULT 1,
+				created_at TEXT NOT NULL DEFAULT (datetime('now')),
+				last_used_at TEXT
+			);
+		`);
+
+		// Insert a pre-existing key row (no scopes column yet).
+		db.exec(
+			`INSERT INTO api_keys (id, name, key_hash, key_prefix) VALUES ('old-key-id', 'legacy-key', 'deadbeef', 'ap_deadbeef')`,
+		);
+
+		// Confirm the scopes column is absent before running init.
+		const colsBefore = getColumnNames(db, "api_keys");
+		expect(colsBefore, "scopes column should not exist on the pre-AGEN-9 schema").not.toContain(
+			SCOPES_COLUMN,
+		);
+
+		// Run the legacy init — it must apply the idempotent ALTER and add scopes.
+		await initializeDatabase(db);
+
+		// scopes column must now exist.
+		const colsAfter = getColumnNames(db, "api_keys");
+		expect(
+			colsAfter,
+			"expected scopes column on api_keys after legacy init (AGEN-9 ALTER migration)",
+		).toContain(SCOPES_COLUMN);
+
+		// The existing row must read '["ingest"]' (column DEFAULT backfill).
+		const rows = db.prepare("SELECT scopes FROM api_keys WHERE id = 'old-key-id'").all() as Array<{
+			scopes: string;
+		}>;
+		expect(rows).toHaveLength(1);
+		expect(rows[0].scopes).toBe('["ingest"]');
 
 		db.close();
 	});

--- a/src/server/db/schema/core/api-keys.ts
+++ b/src/server/db/schema/core/api-keys.ts
@@ -16,6 +16,7 @@ export const apiKeysSqlite = sqliteTable("api_keys", {
 	isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
 	createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
 	lastUsedAt: text("last_used_at"),
+	scopes: text("scopes").notNull().default('["ingest"]'),
 });
 
 export const apiKeysPg = pgTable("api_keys", {
@@ -28,4 +29,5 @@ export const apiKeysPg = pgTable("api_keys", {
 	isActive: boolean("is_active").notNull().default(true),
 	createdAt: tsColumn("postgres", "created_at"),
 	lastUsedAt: pgText("last_used_at"),
+	scopes: pgText("scopes").notNull().default('["ingest"]'),
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,7 +1,6 @@
 import packageJson from "../../package.json" with { type: "json" };
 import { app } from "./app.js";
 import { ensureDefaultApiKey } from "./auth/api-key.js";
-import { getAuthUserFromHeaders } from "./auth/middleware.js";
 import { config } from "./config.js";
 import { initializeDatabase } from "./db/client.js";
 import { setShuttingDown } from "./drain-state.js";
@@ -35,6 +34,7 @@ import {
 	initWsBroadcaster,
 	startHeartbeat,
 } from "./ws/handler.js";
+import { guardWsUpgrade } from "./ws/ws-auth.js";
 
 // ── Graceful drain state ──────────────────────────────────────────────────────
 //
@@ -165,12 +165,8 @@ bunServer = Bun.serve({
 				return new Response("Forbidden", { status: 403 });
 			}
 
-			const authUser = config.disableAuth
-				? { source: "api_key", name: "anonymous", id: "anonymous" }
-				: await getAuthUserFromHeaders(req.headers);
-			if (!authUser) {
-				return new Response("Unauthorized", { status: 401 });
-			}
+			const wsReject = await guardWsUpgrade(req.headers);
+			if (wsReject) return wsReject;
 			const s = server as { upgrade(req: Request): boolean };
 			const upgraded = s.upgrade(req);
 			if (upgraded) return undefined as unknown as Response;
@@ -267,6 +263,14 @@ console.log("");
 console.log(
 	`[config] Binding to ${config.host}:${config.port}; set HOST=0.0.0.0 to expose to LAN/network.`,
 );
+
+// Scope-bypass advisory: DISABLE_AUTH=true makes requireScope() a no-op
+// (all callers get scopes:["*"]). Fine for local dev; never use in production.
+if (config.disableAuth) {
+	console.warn(
+		"[auth] DISABLE_AUTH=true — scope enforcement is bypassed. All API routes are open.",
+	);
+}
 
 // One-shot footgun warning. DISABLE_AUTH=true binds every mutation route
 // (sessions, projects, templates, ai control plane) wide-open; combined

--- a/src/server/routes/ask.ts
+++ b/src/server/routes/ask.ts
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
 import { Hono } from "hono";
-import { requireAuth } from "../auth/middleware.js";
+import { requireAuth, requireScope } from "../auth/middleware.js";
 import { isAiActive, isAiBuildEnabled } from "../services/ai/feature.js";
 import {
 	archiveThread,
@@ -19,8 +19,11 @@ import { isLabsFlagEnabled } from "../services/labs-service.js";
  * who haven't opted in don't accidentally spin up LLM calls.
  */
 const askRouter = new Hono();
-askRouter.use("/ai/ask/*", requireAuth());
-askRouter.use("/ai/ask", requireAuth());
+// Router-level guards so any future route on this router is covered regardless
+// of its path (path-prefixed use() only fires on matching paths, which would
+// silently miss a hypothetical non-/ai/ask route added later).
+askRouter.use("*", requireAuth());
+askRouter.use("*", requireScope("manage"));
 
 async function ensureEnabled(c: Context) {
 	if (!isAiBuildEnabled()) {

--- a/src/server/routes/channels.ts
+++ b/src/server/routes/channels.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { requireAuth } from "../auth/middleware.js";
+import { requireAuth, requireScope } from "../auth/middleware.js";
 import { config } from "../config.js";
 import { getActionRequest, resolveActionRequest } from "../services/ai/action-requests-service.js";
 import { emitAiEvent } from "../services/ai/ai-events.js";
@@ -310,19 +310,15 @@ async function handleActionCallback(cb: TelegramCallbackQuery): Promise<void> {
 
 // --- Authenticated admin CRUD below ---
 //
-// Per-route `requireAuth()` instead of `.use("/channels/*", ...)`: Hono's
-// path-prefixed `use()` fires on any matching request regardless of
-// registration order, and merging routers via `api.route()` doesn't
-// isolate that middleware from unrelated routes bundled alongside. The
-// one public route we absolutely must keep unauthenticated is the
-// Telegram webhook (public by design, HMAC-authenticated via header),
-// and the simplest way to guarantee it never gets shadowed by auth is
-// to attach auth per-handler rather than path-globally.
-
+// The public Telegram webhook lives on `telegramWebhookRouter`, which is
+// mounted directly on the root app *outside* the `api` bundle. That means
+// any `.use("*", ...)` here on channelsRouter cannot reach it — so we can
+// safely use router-level middleware without shadowing the webhook. (M-1)
 const channelsRouter = new Hono();
-const auth = requireAuth();
+channelsRouter.use("*", requireAuth());
+channelsRouter.use("*", requireScope("manage"));
 
-channelsRouter.get("/channels", auth, async (c) => {
+channelsRouter.get("/channels", async (c) => {
 	const channels = await listChannels();
 	return c.json({
 		channels,
@@ -333,7 +329,7 @@ channelsRouter.get("/channels", auth, async (c) => {
 	});
 });
 
-channelsRouter.post("/channels", auth, async (c) => {
+channelsRouter.post("/channels", async (c) => {
 	if (!getTelegramBotToken()) {
 		return c.json({ error: "Telegram bot token not configured" }, 400);
 	}
@@ -356,7 +352,7 @@ channelsRouter.post("/channels", auth, async (c) => {
 	);
 });
 
-channelsRouter.delete("/channels/:id", auth, async (c) => {
+channelsRouter.delete("/channels/:id", async (c) => {
 	const id = c.req.param("id") ?? "";
 	const ok = await deleteChannel(id);
 	if (!ok) return c.json({ error: "Channel not found" }, 404);
@@ -368,7 +364,7 @@ channelsRouter.delete("/channels/:id", auth, async (c) => {
  * key not on the allow-list so callers can't poke at enrollment codes
  * or status strings through this endpoint.
  */
-channelsRouter.patch("/channels/:id/config", auth, async (c) => {
+channelsRouter.patch("/channels/:id/config", async (c) => {
 	const id = c.req.param("id") ?? "";
 	const body = await c.req.json<{ askEnabled?: boolean }>();
 	const patch: Record<string, unknown> = {};
@@ -381,7 +377,7 @@ channelsRouter.patch("/channels/:id/config", auth, async (c) => {
 	return c.json({ channel: updated });
 });
 
-channelsRouter.get("/channels/:id", auth, async (c) => {
+channelsRouter.get("/channels/:id", async (c) => {
 	const id = c.req.param("id") ?? "";
 	const ch = await getChannel(id);
 	if (!ch) return c.json({ error: "Channel not found" }, 404);
@@ -410,7 +406,7 @@ function resolvePublicUrl(candidate: unknown): string | null {
  * `window.location.origin` — saves admins from having to set the
  * PUBLIC_URL env var just for this.
  */
-channelsRouter.post("/channels/telegram/setup-webhook", auth, async (c) => {
+channelsRouter.post("/channels/telegram/setup-webhook", async (c) => {
 	if (!getTelegramBotToken()) return c.json({ error: "Telegram bot token not configured" }, 400);
 	if (!getTelegramWebhookSecret()) {
 		return c.json({ error: "Telegram webhook secret not configured" }, 400);
@@ -437,7 +433,7 @@ channelsRouter.post("/channels/telegram/setup-webhook", auth, async (c) => {
  * getMe, and auto-register the webhook when a public URL is known so
  * the enrollment flow works end-to-end without a second click.
  */
-channelsRouter.get("/channels/telegram/credentials", auth, async (c) => {
+channelsRouter.get("/channels/telegram/credentials", async (c) => {
 	return c.json({
 		configured: Boolean(getTelegramBotToken()),
 		webhookSecretConfigured: Boolean(getTelegramWebhookSecret()),
@@ -448,7 +444,7 @@ channelsRouter.get("/channels/telegram/credentials", auth, async (c) => {
 	});
 });
 
-channelsRouter.post("/channels/telegram/credentials", auth, async (c) => {
+channelsRouter.post("/channels/telegram/credentials", async (c) => {
 	const body = await c.req.json<{
 		botToken?: string;
 		webhookSecret?: string;
@@ -567,7 +563,7 @@ channelsRouter.post("/channels/telegram/credentials", auth, async (c) => {
 	});
 });
 
-channelsRouter.delete("/channels/telegram/credentials", auth, async (c) => {
+channelsRouter.delete("/channels/telegram/credentials", async (c) => {
 	if (getTelegramBotToken()) {
 		await deleteTelegramWebhook().catch(() => {
 			// ignore — we're wiping credentials regardless of Telegram's
@@ -583,20 +579,20 @@ channelsRouter.delete("/channels/telegram/credentials", auth, async (c) => {
 	});
 });
 
-channelsRouter.post("/channels/telegram/teardown-webhook", auth, async (c) => {
+channelsRouter.post("/channels/telegram/teardown-webhook", async (c) => {
 	if (!getTelegramBotToken()) return c.json({ error: "Telegram bot token not configured" }, 400);
 	await deleteTelegramWebhook();
 	return c.json({ ok: true });
 });
 
-channelsRouter.get("/channels/telegram/bot-info", auth, async (c) => {
+channelsRouter.get("/channels/telegram/bot-info", async (c) => {
 	if (!getTelegramBotToken()) return c.json({ error: "Telegram bot token not configured" }, 400);
 	const res = await getTelegramBotInfo();
 	if (!res.ok) return c.json({ error: res.error }, 502);
 	return c.json({ bot: res.info });
 });
 
-channelsRouter.get("/channels/telegram/webhook-info", auth, async (c) => {
+channelsRouter.get("/channels/telegram/webhook-info", async (c) => {
 	if (!getTelegramBotToken()) return c.json({ error: "Telegram bot token not configured" }, 400);
 	const res = await getTelegramWebhookInfo();
 	if (!res.ok) return c.json({ error: res.error }, 502);
@@ -613,7 +609,7 @@ channelsRouter.get("/channels/telegram/webhook-info", auth, async (c) => {
 	});
 });
 
-channelsRouter.post("/channels/:id/test", auth, async (c) => {
+channelsRouter.post("/channels/:id/test", async (c) => {
 	const id = c.req.param("id") ?? "";
 	const ch = await getChannel(id);
 	if (!ch) return c.json({ error: "Channel not found" }, 404);
@@ -624,7 +620,7 @@ channelsRouter.post("/channels/:id/test", auth, async (c) => {
 	return c.json({ ok: true, externalMessageId: res.externalMessageId });
 });
 
-channelsRouter.get("/channels/:id/stats", auth, async (c) => {
+channelsRouter.get("/channels/:id/stats", async (c) => {
 	const id = c.req.param("id") ?? "";
 	const ch = await getChannel(id);
 	if (!ch) return c.json({ error: "Channel not found" }, 404);

--- a/src/server/routes/labs.ts
+++ b/src/server/routes/labs.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { requireAuth } from "../auth/middleware.js";
+import { requireAuth, requireScope } from "../auth/middleware.js";
 import {
 	LABS_REGISTRY,
 	type LabsFlag,
@@ -9,6 +9,7 @@ import {
 
 const labsRouter = new Hono();
 labsRouter.use("*", requireAuth());
+labsRouter.use("*", requireScope("manage"));
 
 labsRouter.get("/labs/flags", async (c) => {
 	const flags = await getLabsFlags();

--- a/src/server/routes/launches.ts
+++ b/src/server/routes/launches.ts
@@ -2,7 +2,7 @@ import { desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { LaunchRequestInput, SessionTemplateInput } from "../../shared/types.js";
-import { requireAuth } from "../auth/middleware.js";
+import { requireAuth, requireScope } from "../auth/middleware.js";
 import { getDb } from "../db/client.js";
 import { launchRequests, sessionTemplates } from "../db/schema/index.js";
 import { isAiBuildEnabled } from "../services/ai/feature.js";
@@ -14,6 +14,7 @@ import { resolveTemplateWithProject } from "../services/templates/template-proje
 
 const launchesRouter = new Hono();
 launchesRouter.use("*", requireAuth());
+launchesRouter.use("*", requireScope("manage"));
 
 launchesRouter.get("/launches", async (c) => {
 	const rows = await getDb().select().from(launchRequests).orderBy(desc(launchRequests.createdAt));

--- a/src/server/routes/projects.ts
+++ b/src/server/routes/projects.ts
@@ -2,7 +2,7 @@ import { desc, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { AGENT_TYPES } from "../../shared/constants.js";
 import type { AgentType } from "../../shared/types.js";
-import { requireAuth } from "../auth/middleware.js";
+import { requireAuth, requireScope } from "../auth/middleware.js";
 import { getDb } from "../db/client.js";
 import { type projects, sessions } from "../db/schema/index.js";
 import { queueCleanupWorkArea } from "../services/control-actions.js";
@@ -18,6 +18,7 @@ import { listSupervisors } from "../services/supervisor-registry.js";
 
 const projectsRouter = new Hono();
 projectsRouter.use("*", requireAuth());
+projectsRouter.use("*", requireScope("manage"));
 
 function mapProject(row: typeof projects.$inferSelect) {
 	return {

--- a/src/server/routes/search.ts
+++ b/src/server/routes/search.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { requireAuth } from "../auth/middleware.js";
+import { requireAuth, requireScope } from "../auth/middleware.js";
 import { getSearchBackend } from "../services/search/index.js";
 import type { SearchFilters, SearchRowKind } from "../services/search/types.js";
 
@@ -14,7 +14,8 @@ import type { SearchFilters, SearchRowKind } from "../services/search/types.js";
  * backend — untrusted input never reaches raw SQL.
  */
 const searchRouter = new Hono();
-const auth = requireAuth();
+searchRouter.use("*", requireAuth());
+searchRouter.use("*", requireScope("manage"));
 
 function parseKinds(input: string | undefined): SearchRowKind[] | undefined {
 	if (!input) return undefined;
@@ -37,7 +38,7 @@ function parseSessionStatus(
 		: undefined;
 }
 
-searchRouter.get("/search", auth, async (c) => {
+searchRouter.get("/search", async (c) => {
 	const q = c.req.query("q")?.trim() ?? "";
 	if (!q) {
 		return c.json({ hits: [], total: 0, backend: getSearchBackend().name });
@@ -66,13 +67,8 @@ searchRouter.get("/search", auth, async (c) => {
 	}
 });
 
-/**
- * Admin-only — rebuilds the FTS index from scratch. Useful after
- * bulk imports or schema changes. Currently auth'd as any logged-in
- * user; Phase 4 of the security plan will narrow this to admin-only
- * once requireAdmin() exists.
- */
-searchRouter.post("/search/rebuild", auth, async (c) => {
+/** Rebuild the FTS index from scratch. Requires manage scope (router-level gate). */
+searchRouter.post("/search/rebuild", async (c) => {
 	try {
 		const res = await getSearchBackend().rebuild();
 		return c.json({ ok: true, ...res });

--- a/src/server/routes/sessions.ts
+++ b/src/server/routes/sessions.ts
@@ -1,7 +1,7 @@
 import { and, asc, desc, eq, gt, lte } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AgentType, SessionStatus } from "../../shared/types.js";
-import { requireAuth } from "../auth/middleware.js";
+import { requireAuth, requireScope } from "../auth/middleware.js";
 import { getDb } from "../db/client.js";
 import { events, sessions } from "../db/schema/index.js";
 import { withTransaction } from "../db/with-transaction.js";
@@ -15,6 +15,10 @@ import { getSession, getSessions, getStats, renameSession } from "../services/se
 
 const sessionsRouter = new Hono();
 sessionsRouter.use("*", requireAuth());
+// Session data is operator-only. Ingest keys must not list session history,
+// read event timelines, or mutate session state (rename, notes, archive).
+// Relay users must use a manage-scoped key (see scripts/setup-relay.sh).
+sessionsRouter.use("*", requireScope("manage"));
 
 // GET /api/v1/sessions - List sessions
 sessionsRouter.get("/sessions", async (c) => {

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { createApiKey } from "../auth/api-key.js";
-import { requireAuth } from "../auth/middleware.js";
+import { InvalidScopeError, createApiKey, parseScopes } from "../auth/api-key.js";
+import { requireAuth, requireScope } from "../auth/middleware.js";
 import { getDb } from "../db/client.js";
 import { apiKeys, settings } from "../db/schema/index.js";
 import { ProtectedSettingError, upsertSetting } from "../services/settings-service.js";
@@ -14,6 +14,9 @@ import {
 
 const settingsRouter = new Hono();
 settingsRouter.use("*", requireAuth());
+// All settings routes are operator-only (H-1, H-2): ingest keys must not
+// read or write settings, workspace defaults, or API-key management.
+settingsRouter.use("*", requireScope("manage"));
 
 // GET /api/v1/settings - Get all settings
 settingsRouter.get("/settings", async (c) => {
@@ -162,9 +165,9 @@ settingsRouter.put("/settings/workspace", async (c) => {
 	}
 });
 
-// GET /api/v1/api-keys - List all API keys (without the actual key)
+// GET /api/v1/api-keys - List all API keys (without the actual key).
 settingsRouter.get("/api-keys", async (c) => {
-	const keys = await getDb()
+	const rows = await getDb()
 		.select({
 			id: apiKeys.id,
 			name: apiKeys.name,
@@ -172,32 +175,42 @@ settingsRouter.get("/api-keys", async (c) => {
 			isActive: apiKeys.isActive,
 			createdAt: apiKeys.createdAt,
 			lastUsedAt: apiKeys.lastUsedAt,
+			scopes: apiKeys.scopes,
 		})
 		.from(apiKeys)
 		.orderBy(apiKeys.createdAt);
 
+	const keys = rows.map((k) => ({ ...k, scopes: parseScopes(k.scopes) }));
 	return c.json({ keys });
 });
 
-// POST /api/v1/api-keys - Create a new API key
+// POST /api/v1/api-keys - Create a new API key.
 settingsRouter.post("/api-keys", async (c) => {
-	const { name } = await c.req.json<{ name: string }>();
+	const { name, scopes } = await c.req.json<{ name: string; scopes?: string[] }>();
 
 	if (!name || name.trim().length === 0) {
 		return c.json({ error: "Name is required" }, 400);
 	}
 
-	const { key, id } = await createApiKey(name.trim());
+	try {
+		const { key, id } = await createApiKey(name.trim(), scopes);
 
-	return c.json({
-		id,
-		key, // Only returned once on creation
-		name: name.trim(),
-		message: "Save this key -- it will not be shown again.",
-	});
+		return c.json({
+			id,
+			key, // Only returned once on creation
+			name: name.trim(),
+			scopes: scopes ?? ["ingest"],
+			message: "Save this key -- it will not be shown again.",
+		});
+	} catch (err) {
+		if (err instanceof InvalidScopeError) {
+			return c.json({ error: "invalid_scope", value: err.value }, 400);
+		}
+		throw err;
+	}
 });
 
-// DELETE /api/v1/api-keys/:id - Revoke an API key
+// DELETE /api/v1/api-keys/:id - Revoke an API key.
 settingsRouter.delete("/api-keys/:id", async (c) => {
 	const id = c.req.param("id");
 

--- a/src/server/routes/supervisors-split.test.ts
+++ b/src/server/routes/supervisors-split.test.ts
@@ -20,6 +20,8 @@ const { supervisorsAgentRouter, supervisorsAdminRouter } = await import("./super
 const { createUser, issueSession, SESSION_DURATION_MS } = await import(
 	"../services/local-auth-service.js"
 );
+const { createSupervisorEnrollmentToken } = await import("../auth/supervisor-auth.js");
+const { registerSupervisor } = await import("../services/supervisor-registry.js");
 
 // Mirror the real app.ts mount:
 //   agent router at /api/v1        → /api/v1/supervisors/*
@@ -121,6 +123,112 @@ describe("agent endpoints still reachable on /api/v1/supervisors (AC 9.3)", () =
 		});
 		// requireSupervisorAuth() fires → 401, not 404
 		expect(res.status).toBe(401);
+	});
+});
+
+// ── AGEN-8: unscoped-token slot-takeover guard ────────────────────────────────
+describe("unscoped-token slot-takeover guard (AGEN-8)", () => {
+	test("unscoped token + existing supervisor id → 409 supervisor_exists_use_rotate", async () => {
+		// Directly register a supervisor so it already exists in the DB (the "victim").
+		const { supervisor } = await registerSupervisor({
+			hostName: "slot-takeover-victim",
+			platform: "linux",
+			arch: "x64",
+			version: "1.0.0",
+			capabilities: {
+				version: 1,
+				agentTypes: ["claude_code"],
+				launchModes: ["headless"],
+				os: "linux",
+				terminalSupport: [],
+				features: [],
+			},
+			trustedRoots: [],
+		});
+
+		// Create an UNSCOPED enrollment token (supervisorId = null).
+		const { token } = await createSupervisorEnrollmentToken("attacker-unscoped", null, null);
+
+		// Attempt to register the victim's id using the unscoped token.
+		const res = await app.request("/api/v1/supervisors/register", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				hostName: "attacker-host",
+				platform: "linux",
+				arch: "x64",
+				version: "1.0.0",
+				enrollmentToken: token,
+				id: supervisor.id, // ← the takeover vector
+			}),
+		});
+		expect(res.status).toBe(409);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe("supervisor_exists_use_rotate");
+	});
+
+	test("unscoped token + non-existent id → succeeds and returns credential", async () => {
+		const { token } = await createSupervisorEnrollmentToken("fresh-unscoped", null, null);
+		const freshId = crypto.randomUUID(); // guaranteed not in DB
+
+		const res = await app.request("/api/v1/supervisors/register", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				hostName: "brand-new-host",
+				platform: "darwin",
+				arch: "arm64",
+				version: "1.0.0",
+				enrollmentToken: token,
+				id: freshId,
+			}),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { supervisorCredential: string };
+		expect(typeof body.supervisorCredential).toBe("string");
+	});
+
+	test("scoped token (rotate path) is unaffected even when supervisor already exists", async () => {
+		// Register a supervisor directly.
+		const { supervisor } = await registerSupervisor({
+			hostName: "scoped-rotate-host",
+			platform: "linux",
+			arch: "x64",
+			version: "1.0.0",
+			capabilities: {
+				version: 1,
+				agentTypes: ["claude_code"],
+				launchModes: ["headless"],
+				os: "linux",
+				terminalSupport: [],
+				features: [],
+			},
+			trustedRoots: [],
+		});
+
+		// The admin rotate endpoint issues a SCOPED token bound to supervisor.id.
+		const { token } = await createSupervisorEnrollmentToken(
+			`rotate:${supervisor.hostName}`,
+			null,
+			supervisor.id, // ← scoped
+		);
+
+		// Registration via scoped token: the guard must NOT fire.
+		const res = await app.request("/api/v1/supervisors/register", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				hostName: "scoped-rotate-host",
+				platform: "linux",
+				arch: "x64",
+				version: "1.0.0",
+				enrollmentToken: token,
+				// id intentionally omitted — token provides it
+			}),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { supervisorCredential: string };
+		expect(typeof body.supervisorCredential).toBe("string");
 	});
 });
 

--- a/src/server/routes/supervisors.ts
+++ b/src/server/routes/supervisors.ts
@@ -4,7 +4,7 @@ import type {
 	ManagedSessionStateInput,
 	SupervisorRegistrationInput,
 } from "../../shared/types.js";
-import { requireAuth, requireSupervisorAuth } from "../auth/middleware.js";
+import { requireAuth, requireScope, requireSupervisorAuth } from "../auth/middleware.js";
 import {
 	consumeEnrollmentToken,
 	createSupervisorCredential,
@@ -40,19 +40,25 @@ import {
 
 const supervisorsAdminRouter = new Hono();
 
-supervisorsAdminRouter.get("/supervisors", requireAuth(), async (c) => {
+// Gate the entire admin router: must be authenticated AND carry the "manage" scope.
+// forwardauth/local sessions pass requireScope unconditionally; only api_key callers
+// are checked for the "manage" capability.
+supervisorsAdminRouter.use("*", requireAuth());
+supervisorsAdminRouter.use("*", requireScope("manage"));
+
+supervisorsAdminRouter.get("/supervisors", async (c) => {
 	const supervisors = await listSupervisors();
 	return c.json({ supervisors, total: supervisors.length });
 });
 
-supervisorsAdminRouter.get("/supervisors/:id", requireAuth(), async (c) => {
+supervisorsAdminRouter.get("/supervisors/:id", async (c) => {
 	const supervisorId = c.req.param("id") ?? "";
 	const supervisor = await getSupervisor(supervisorId);
 	if (!supervisor) return c.json({ error: "Supervisor not found" }, 404);
 	return c.json({ supervisor });
 });
 
-supervisorsAdminRouter.post("/supervisors/enroll", requireAuth(), async (c) => {
+supervisorsAdminRouter.post("/supervisors/enroll", async (c) => {
 	const body = await c.req.json<{
 		name?: string;
 		expiresAt?: string | null;
@@ -66,7 +72,7 @@ supervisorsAdminRouter.post("/supervisors/enroll", requireAuth(), async (c) => {
 	return c.json(result, 201);
 });
 
-supervisorsAdminRouter.post("/supervisors/:id/rotate", requireAuth(), async (c) => {
+supervisorsAdminRouter.post("/supervisors/:id/rotate", async (c) => {
 	const supervisorId = c.req.param("id") ?? "";
 	const supervisor = await getSupervisor(supervisorId);
 	if (!supervisor) return c.json({ error: "Supervisor not found" }, 404);
@@ -79,7 +85,7 @@ supervisorsAdminRouter.post("/supervisors/:id/rotate", requireAuth(), async (c) 
 	return c.json(result, 201);
 });
 
-supervisorsAdminRouter.post("/supervisors/:id/revoke", requireAuth(), async (c) => {
+supervisorsAdminRouter.post("/supervisors/:id/revoke", async (c) => {
 	const supervisorId = c.req.param("id") ?? "";
 	await revokeSupervisor(supervisorId);
 	await revokeSupervisorCredential(supervisorId);

--- a/src/server/routes/supervisors.ts
+++ b/src/server/routes/supervisors.ts
@@ -128,6 +128,16 @@ supervisorsAgentRouter.post("/supervisors/register", async (c) => {
 					return c.json({ error: "Enrollment token is scoped to a different supervisor" }, 403);
 				}
 				registrationInput.id = verifiedEnrollment.supervisorId;
+			} else if (registrationInput.id) {
+				// Unscoped enrollment token + explicit supervisor id = slot-takeover vector.
+				// registerSupervisor upserts on id and revokeSupervisorCredential would revoke
+				// the victim's live credential, handing a fresh one to the caller.
+				// Block it here; the legitimate re-keying path is the scoped /admin/supervisors/:id/rotate
+				// endpoint, which issues an enrollment token scoped to the specific supervisor.
+				const existing = await getSupervisor(registrationInput.id);
+				if (existing) {
+					return c.json({ error: "supervisor_exists_use_rotate" }, 409);
+				}
 			}
 			const consumed = await consumeEnrollmentToken(registrationInput.enrollmentToken);
 			if (!consumed) return c.json({ error: "Enrollment token is no longer valid" }, 409);

--- a/src/server/routes/templates.ts
+++ b/src/server/routes/templates.ts
@@ -1,7 +1,7 @@
 import { desc, eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 import type { AgentType, LaunchMode, SessionTemplateInput } from "../../shared/types.js";
-import { requireAuth } from "../auth/middleware.js";
+import { requireAuth, requireScope } from "../auth/middleware.js";
 import { getDb } from "../db/client.js";
 import { projects, sessionTemplates } from "../db/schema/index.js";
 import { ensureProjectForCwd, getProject } from "../services/projects/projects-service.js";
@@ -19,6 +19,7 @@ import {
 
 const templatesRouter = new Hono();
 templatesRouter.use("*", requireAuth());
+templatesRouter.use("*", requireScope("manage"));
 
 templatesRouter.get("/templates", async (c) => {
 	const agentType = c.req.query("agent_type") as AgentType | undefined;

--- a/src/server/services/ai/embeddings/embedding-service.circuit.test.ts
+++ b/src/server/services/ai/embeddings/embedding-service.circuit.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Circuit-breaker tests for the embedding-service backfill loop (AGEN-7).
+ *
+ * Injects a failing adapter and verifies:
+ *   1. The loop makes a bounded number of attempts (≤ MAX_CONSECUTIVE_FAILURES).
+ *   2. The circuit opens and the loop exits cleanly rather than spinning forever.
+ *   3. A succeeding adapter completes normally and does not set circuitOpen.
+ *
+ * Uses the real in-memory SQLite DB so the batch query path is exercised end-to-end.
+ * Backoff delay is overridden to 0 ms for instant test cycles.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import "../../../db/__test_db.js";
+
+const { config } = await import("../../../config.js");
+const { initializeDatabase, getDb, getSqlite } = await import("../../../db/client.js");
+const { sessions, events } = await import("../../../db/schema/index.js");
+const {
+	runBackfill,
+	__resetEmbeddingAdapterForTests,
+	__setEmbeddingAdapterForTests,
+	__setBackfillBackoffForTests,
+} = await import("./embedding-service.js");
+
+const originalVectorSearch = config.vectorSearchEnabled;
+
+// Use a non-existent session id unique to this test file to avoid FK collisions with
+// other test suites that may run concurrently in the same temp DB.
+const SESSION_ID = "circuit-test-session-embed";
+
+beforeAll(async () => {
+	await initializeDatabase();
+	// Enable vector search for the duration of this suite.
+	// dialect resolves naturally to "sqlite" since DATABASE_URL is unset in tests.
+	(config as Record<string, unknown>).vectorSearchEnabled = true;
+	// Seed parent session once — events FK requires it.
+	await getDb()
+		.insert(sessions)
+		.values({ sessionId: SESSION_ID, agentType: "claude_code" })
+		.onConflictDoNothing();
+	// Use zero-delay backoff for all tests in this file.
+	__setBackfillBackoffForTests(() => 0);
+});
+
+afterAll(() => {
+	// Restore original config value so other test suites are unaffected.
+	(config as Record<string, unknown>).vectorSearchEnabled = originalVectorSearch;
+	// Restore default backoff so other test suites are unaffected.
+	__setBackfillBackoffForTests((attempt) => Math.min(1_000 * 2 ** (attempt - 1), 30_000));
+	__resetEmbeddingAdapterForTests();
+});
+
+beforeEach(async () => {
+	// Clear state between tests.
+	__resetEmbeddingAdapterForTests();
+	getSqlite().exec("DELETE FROM event_embeddings");
+	await getDb().delete(events).execute();
+	// Insert one event so the batch query returns rows and we reach the embed call.
+	await getDb()
+		.insert(events)
+		.values({
+			sessionId: SESSION_ID,
+			eventType: "UserPromptSubmit",
+			rawPayload: { prompt: "hello circuit breaker" },
+		});
+});
+
+describe("embedding-service circuit breaker (AGEN-7)", () => {
+	test("adapter that always throws opens circuit after MAX_CONSECUTIVE_FAILURES attempts", async () => {
+		let callCount = 0;
+		__setEmbeddingAdapterForTests({
+			kind: "ollama",
+			model: "circuit-test-model",
+			dim: 4,
+			embed: async (_input: string): Promise<Float32Array> => {
+				callCount++;
+				throw new Error("connection refused");
+			},
+		});
+
+		const result = await runBackfill();
+
+		// Loop must exit cleanly — not still running.
+		expect(result.running).toBe(false);
+		// Error state must indicate circuit open.
+		expect(result.error).toMatch(/circuit open/);
+		// Exactly MAX_CONSECUTIVE_FAILURES (5) attempts before breaking.
+		expect(callCount).toBeGreaterThan(0);
+		expect(callCount).toBeLessThanOrEqual(5);
+	});
+
+	test("does NOT spin forever on persistent failure (batch attempt count is bounded)", async () => {
+		// Track batch-level attempts (one call to embedBatch per loop iteration).
+		// With N texts in a batch, using embed() would multiply the call count by N,
+		// obscuring the "bounded number of LOOP ITERATIONS" invariant we care about.
+		let batchAttempts = 0;
+		__setEmbeddingAdapterForTests({
+			kind: "ollama",
+			model: "circuit-test-model",
+			dim: 4,
+			embed: async (_input: string): Promise<Float32Array> => {
+				throw new Error("endpoint permanently down");
+			},
+			// embedBatch is called once per loop iteration, making the counter directly
+			// correspond to consecutive-failure count (≤ MAX_CONSECUTIVE_FAILURES = 5).
+			embedBatch: async (_inputs: string[]): Promise<Float32Array[]> => {
+				batchAttempts++;
+				throw new Error("endpoint permanently down");
+			},
+		});
+
+		// Insert extra events to ensure multiple-batch territory, confirming the
+		// circuit opens after the failure limit, not after a single event processes.
+		for (let i = 0; i < 40; i++) {
+			await getDb()
+				.insert(events)
+				.values({
+					sessionId: SESSION_ID,
+					eventType: "AssistantMessage",
+					rawPayload: { message: `msg ${i}` },
+				});
+		}
+
+		const result = await runBackfill();
+
+		// The circuit must open after exactly MAX_CONSECUTIVE_FAILURES batch attempts.
+		// This is the definitive "does NOT loop forever" assertion.
+		expect(batchAttempts).toBeGreaterThan(0);
+		expect(batchAttempts).toBeLessThanOrEqual(5);
+		expect(result.running).toBe(false);
+		expect(result.error).toMatch(/circuit open/);
+	});
+
+	test("succeeding adapter completes normally without circuit-open error", async () => {
+		const fakeVector = new Float32Array(4).fill(0.25);
+		let callCount = 0;
+		__setEmbeddingAdapterForTests({
+			kind: "ollama",
+			model: "circuit-test-model",
+			dim: 4,
+			embed: async (_input: string): Promise<Float32Array> => {
+				callCount++;
+				return fakeVector;
+			},
+		});
+
+		const result = await runBackfill();
+
+		expect(result.running).toBe(false);
+		expect(result.error).toBeNull();
+		// At least one embed call for our inserted event.
+		expect(callCount).toBeGreaterThan(0);
+	});
+
+	test("circuit resets per runBackfill invocation — a fresh call after circuit-open starts with zero failures", async () => {
+		let failingCalls = 0;
+		__setEmbeddingAdapterForTests({
+			kind: "ollama",
+			model: "circuit-test-model",
+			dim: 4,
+			embed: async (_input: string): Promise<Float32Array> => {
+				failingCalls++;
+				throw new Error("down");
+			},
+		});
+
+		const first = await runBackfill();
+		expect(first.error).toMatch(/circuit open/);
+
+		// Second invocation: adapter still failing but circuit counter resets.
+		const callsBefore = failingCalls;
+		const second = await runBackfill();
+		expect(second.error).toMatch(/circuit open/);
+		// Second run also made up to 5 new attempts (not 0 because counter was reset).
+		expect(failingCalls - callsBefore).toBeGreaterThan(0);
+		expect(failingCalls - callsBefore).toBeLessThanOrEqual(5);
+	});
+});

--- a/src/server/services/ai/embeddings/embedding-service.ts
+++ b/src/server/services/ai/embeddings/embedding-service.ts
@@ -59,6 +59,10 @@ export interface BackfillProgress {
 let cachedAdapter: EmbeddingAdapter | null = null;
 let cachedAdapterKey: string | null = null;
 
+const BACKFILL_MAX_CONSECUTIVE_FAILURES = 5;
+// Overridable for tests — __setBackfillBackoffForTests.
+let _backoffDelayMs = (attempt: number) => Math.min(1_000 * 2 ** (attempt - 1), 30_000);
+
 let backfillState: BackfillProgress = {
 	total: 0,
 	embedded: 0,
@@ -85,6 +89,8 @@ async function readSetting(key: string): Promise<unknown> {
  * tolerate null — vector search just becomes a no-op.
  */
 export async function resolveEmbeddingAdapter(): Promise<EmbeddingAdapter | null> {
+	// Test bypass — __setEmbeddingAdapterForTests injects this sentinel key.
+	if (cachedAdapterKey === "__test_forced__") return cachedAdapter;
 	if (config.dialect !== "sqlite" || !isVectorSearchBuildEnabled()) return null;
 
 	const providerId = (await readSetting(VECTOR_SEARCH_PROVIDER_ID_KEY)) as string | null;
@@ -262,6 +268,8 @@ export async function runBackfill(): Promise<BackfillProgress> {
 		// inline and queries for "missing" reflect that immediately.
 		const batchSize = 32;
 		let processed = 0;
+		let consecutiveFailures = 0;
+		let circuitOpen = false;
 		while (true) {
 			const batch = getSqlite()
 				.prepare(
@@ -317,9 +325,25 @@ export async function runBackfill(): Promise<BackfillProgress> {
 						? await adapter.embedBatch(texts)
 						: await Promise.all(texts.map((t) => adapter.embed(t)));
 				} catch (err) {
+					consecutiveFailures++;
 					backfillState.error = err instanceof Error ? err.message : String(err);
 					console.warn("[embeddings] batch embed failed:", err);
-					await new Promise((r) => setTimeout(r, 1000));
+					if (consecutiveFailures >= BACKFILL_MAX_CONSECUTIVE_FAILURES) {
+						console.warn(
+							JSON.stringify({
+								kind: "embedding_circuit_open",
+								level: "warn",
+								consecutiveFailures,
+								model: adapter.model,
+								lastError: backfillState.error,
+							}),
+						);
+						backfillState.error = `circuit open after ${consecutiveFailures} consecutive adapter failures`;
+						circuitOpen = true;
+						break;
+					}
+					const delay = _backoffDelayMs(consecutiveFailures);
+					await new Promise((r) => setTimeout(r, delay));
 					continue;
 				}
 
@@ -335,6 +359,7 @@ export async function runBackfill(): Promise<BackfillProgress> {
 					}
 				});
 				txn(ids.map((id, i) => ({ id, vec: vectors[i] })));
+				consecutiveFailures = 0; // reset on successful batch
 				processed += texts.length;
 			} else {
 				processed += batch.length;
@@ -348,9 +373,15 @@ export async function runBackfill(): Promise<BackfillProgress> {
 
 		backfillState.running = false;
 		backfillState.finishedAt = new Date().toISOString();
-		console.log(
-			`[embeddings] backfill complete: ${processed} events indexed with ${adapter.model}`,
-		);
+		if (circuitOpen) {
+			console.warn(
+				`[embeddings] backfill paused: circuit open after ${BACKFILL_MAX_CONSECUTIVE_FAILURES} consecutive adapter failures — will retry on next scheduled trigger`,
+			);
+		} else {
+			console.log(
+				`[embeddings] backfill complete: ${processed} events indexed with ${adapter.model}`,
+			);
+		}
 	} catch (err) {
 		backfillState.running = false;
 		backfillState.error = err instanceof Error ? err.message : String(err);
@@ -404,6 +435,17 @@ export function loadEventVector(eventId: number, expectedModel: string): Float32
 export function __resetEmbeddingAdapterForTests(): void {
 	cachedAdapter = null;
 	cachedAdapterKey = null;
+}
+
+/** Test-only — inject a specific adapter, bypassing provider resolution. */
+export function __setEmbeddingAdapterForTests(adapter: EmbeddingAdapter | null): void {
+	cachedAdapter = adapter;
+	cachedAdapterKey = "__test_forced__";
+}
+
+/** Test-only — override per-attempt backoff delay (use () => 0 for instant tests). */
+export function __setBackfillBackoffForTests(fn: (attempt: number) => number): void {
+	_backoffDelayMs = fn;
 }
 
 /** Suppress unused-import lint when the file is imported but no exports used. */

--- a/src/server/ws/ws-auth.test.ts
+++ b/src/server/ws/ws-auth.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for guardWsUpgrade (WS scope gate — AGEN-9 extension).
+ *
+ * We test the guard function directly rather than spinning up a real
+ * Bun.serve, because the WS upgrade happens outside the Hono router and
+ * cannot be reached via app.request().
+ *
+ * Uses the same in-process SQLite pattern as app.integration.test.ts:
+ * __test_db.js sets SQLITE_PATH before any module imports, then
+ * initializeDatabase() creates all tables from the schema.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import "../db/__test_db.js";
+
+const { initializeDatabase } = await import("../db/client.js");
+const { createApiKey } = await import("../auth/api-key.js");
+const { SESSION_COOKIE_NAME, issueSession } = await import("../services/local-auth-service.js");
+const { guardWsUpgrade } = await import("./ws-auth.js");
+const { config } = await import("../config.js");
+
+beforeAll(async () => {
+	await initializeDatabase();
+	// Ensure scope checks fire (don't skip due to disableAuth)
+	(config as Record<string, unknown>).disableAuth = false;
+});
+
+afterAll(() => {
+	(config as Record<string, unknown>).disableAuth = true;
+});
+
+function bearerHeaders(key: string): Headers {
+	return new Headers({ Authorization: `Bearer ${key}` });
+}
+
+function cookieHeaders(token: string): Headers {
+	return new Headers({ Cookie: `${SESSION_COOKIE_NAME}=${token}` });
+}
+
+// ─── Ingest-only key: must be rejected (403) ─────────────────────────────────
+
+describe("guardWsUpgrade — ingest-only api_key → 403", () => {
+	test("ingest-scoped key → returns 403 with insufficient_scope", async () => {
+		const { key } = await createApiKey("ws-guard-ingest-only", ["ingest"]);
+		const result = await guardWsUpgrade(bearerHeaders(key));
+		if (!result) throw new Error("expected a rejection Response, got null");
+		expect(result.status).toBe(403);
+		const body = (await result.json()) as { error: string; required: string };
+		expect(body.error).toBe("insufficient_scope");
+		expect(body.required).toBe("manage");
+	});
+});
+
+// ─── Manage-scoped keys: must be allowed (null) ───────────────────────────────
+
+describe("guardWsUpgrade — manage-scoped api_key → allowed", () => {
+	test("ingest+manage key → returns null (allowed)", async () => {
+		const { key } = await createApiKey("ws-guard-ingest-manage", ["ingest", "manage"]);
+		const result = await guardWsUpgrade(bearerHeaders(key));
+		expect(result).toBeNull();
+	});
+
+	test("manage-only key → returns null (WS does not require ingest)", async () => {
+		const { key } = await createApiKey("ws-guard-manage-only", ["manage"]);
+		const result = await guardWsUpgrade(bearerHeaders(key));
+		expect(result).toBeNull();
+	});
+});
+
+// ─── SSO session cookie: must be allowed ─────────────────────────────────────
+// (SSO sessions are self-contained; no local_auth_users row required.)
+
+describe("guardWsUpgrade — SSO session cookie → allowed", () => {
+	test("valid SSO session cookie → returns null (allowed)", async () => {
+		const { token } = await issueSession({
+			userId: "sso:ws-guard-sso-subject",
+			durationMs: 3_600_000,
+			authSource: "forwardauth",
+			ssoSubject: "ws-guard-sso-subject",
+			ssoUsername: "ws-guard-user",
+			provider: "authentik",
+		});
+		const result = await guardWsUpgrade(cookieHeaders(token));
+		expect(result).toBeNull();
+	});
+});
+
+// ─── Unauthenticated: must get 401 ───────────────────────────────────────────
+
+describe("guardWsUpgrade — unauthenticated → 401", () => {
+	test("no auth headers → returns 401", async () => {
+		const result = await guardWsUpgrade(new Headers());
+		if (!result) throw new Error("expected a rejection Response, got null");
+		expect(result.status).toBe(401);
+	});
+
+	test("invalid Bearer token → returns 401", async () => {
+		const result = await guardWsUpgrade(bearerHeaders("ap_completelybogus000000000000"));
+		if (!result) throw new Error("expected a rejection Response, got null");
+		expect(result.status).toBe(401);
+	});
+});

--- a/src/server/ws/ws-auth.ts
+++ b/src/server/ws/ws-auth.ts
@@ -1,0 +1,40 @@
+/**
+ * WebSocket upgrade auth + scope guard.
+ *
+ * Extracted from the Bun.serve fetch handler so it can be unit-tested
+ * independently of the full server boot sequence. Returns null when the
+ * caller is allowed to proceed to upgrade; returns a Response when the
+ * request must be rejected.
+ *
+ * Rules:
+ *  - No authUser (unauthenticated) → 401
+ *  - authUser.source === "api_key" && scopes lacks "manage" or "*" → 403
+ *  - forwardauth/local → pass (humans always have full access)
+ *  - disableAuth → pass (scope enforcement bypassed)
+ */
+import { SCOPE_ALL, SCOPE_MANAGE } from "../auth/api-key.js";
+import { getAuthUserFromHeaders } from "../auth/middleware.js";
+import { config } from "../config.js";
+
+export async function guardWsUpgrade(headers: Headers): Promise<Response | null> {
+	if (config.disableAuth) {
+		return null; // all requests allowed; scope enforcement is bypassed
+	}
+
+	const authUser = await getAuthUserFromHeaders(headers);
+	if (!authUser) {
+		return new Response("Unauthorized", { status: 401 });
+	}
+
+	if (authUser.source === "api_key") {
+		const scopes: string[] = authUser.scopes ?? [];
+		if (!scopes.includes(SCOPE_MANAGE) && !scopes.includes(SCOPE_ALL)) {
+			return new Response(JSON.stringify({ error: "insufficient_scope", required: SCOPE_MANAGE }), {
+				status: 403,
+				headers: { "Content-Type": "application/json" },
+			});
+		}
+	}
+
+	return null; // allowed
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -381,6 +381,8 @@ export interface ApiKeyInfo {
 	isActive: boolean;
 	createdAt: string;
 	lastUsedAt: string | null;
+	/** Capability set. Parsed from the DB's JSON-text column; never raw TEXT. */
+	scopes: string[];
 }
 
 // Dashboard stats

--- a/src/web/components/FirstRunWelcome.tsx
+++ b/src/web/components/FirstRunWelcome.tsx
@@ -50,7 +50,9 @@ export function FirstRunWelcome({ serverUrl }: { serverUrl: string }) {
 		if (!newKeyName.trim()) return;
 		setCreating(true);
 		try {
-			const res = await api.createApiKey(newKeyName.trim());
+			// Hook-setup keys are ingest-only: they go into agent hook config and
+			// must not carry management privileges. Use Settings to mint manage keys.
+			const res = await api.createApiKey(newKeyName.trim(), ["ingest"]);
 			setRevealedKey(res.key);
 			const list = await api.getApiKeys().catch(() => ({ keys: [] as typeof keys }));
 			setKeys(list.keys ?? []);

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -430,14 +430,18 @@ export const api = {
 				isActive: boolean;
 				createdAt: string;
 				lastUsedAt: string | null;
+				scopes: string[];
 			}>;
 		}>("/api-keys"),
 
-	createApiKey: (name: string) =>
-		request<{ id: string; key: string; name: string; message: string }>("/api-keys", {
-			method: "POST",
-			body: JSON.stringify({ name }),
-		}),
+	createApiKey: (name: string, scopes?: string[]) =>
+		request<{ id: string; key: string; name: string; scopes: string[]; message: string }>(
+			"/api-keys",
+			{
+				method: "POST",
+				body: JSON.stringify({ name, ...(scopes !== undefined ? { scopes } : {}) }),
+			},
+		),
 
 	revokeApiKey: (id: string) =>
 		request<{ ok: true }>(`/api-keys/${id}`, {

--- a/src/web/pages/SettingsPage.tsx
+++ b/src/web/pages/SettingsPage.tsx
@@ -25,6 +25,9 @@ export function SettingsPage() {
 	const [apiKeys, setApiKeys] = useState<ApiKeyInfo[]>([]);
 	const [newKeyName, setNewKeyName] = useState("");
 	const [newKeyValue, setNewKeyValue] = useState<string | null>(null);
+	// Scope picker: ingest is on by default; manage is opt-in.
+	const [newKeyScopeIngest, setNewKeyScopeIngest] = useState(true);
+	const [newKeyScopeManage, setNewKeyScopeManage] = useState(false);
 	const [loading, setLoading] = useState(true);
 	const [theme, setTheme] = useState<AppTheme>(resolveInitialTheme());
 	const [settings, setSettings] = useState<Record<string, unknown>>({});
@@ -69,12 +72,19 @@ export function SettingsPage() {
 	async function handleCreateKey() {
 		if (!newKeyName.trim()) return;
 
+		const scopes: string[] = [];
+		if (newKeyScopeIngest) scopes.push("ingest");
+		if (newKeyScopeManage) scopes.push("manage");
+		if (scopes.length === 0) scopes.push("ingest"); // safety: at least ingest
+
 		try {
-			const data = await api.createApiKey(newKeyName.trim());
+			const data = await api.createApiKey(newKeyName.trim(), scopes);
 
 			if (data.key) {
 				setNewKeyValue(data.key);
 				setNewKeyName("");
+				setNewKeyScopeIngest(true);
+				setNewKeyScopeManage(false);
 				// Refresh key list
 				const keysRes = await api.getApiKeys();
 				setApiKeys(keysRes.keys || []);
@@ -400,23 +410,48 @@ export function SettingsPage() {
 					</div>
 				)}
 
-				<div className="flex flex-col sm:flex-row gap-2 mb-4">
-					<input
-						type="text"
-						value={newKeyName}
-						onChange={(e) => setNewKeyName(e.target.value)}
-						placeholder="Key name (e.g. macbook-hooks)"
-						onKeyDown={(e) => e.key === "Enter" && handleCreateKey()}
-						className="flex-1 min-w-0 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
-					/>
-					<button
-						type="button"
-						onClick={handleCreateKey}
-						disabled={!newKeyName.trim()}
-						className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-					>
-						Create Key
-					</button>
+				<div className="flex flex-col gap-2 mb-4">
+					<div className="flex flex-col sm:flex-row gap-2">
+						<input
+							type="text"
+							value={newKeyName}
+							onChange={(e) => setNewKeyName(e.target.value)}
+							placeholder="Key name (e.g. macbook-hooks)"
+							onKeyDown={(e) => e.key === "Enter" && handleCreateKey()}
+							className="flex-1 min-w-0 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+						/>
+						<button
+							type="button"
+							onClick={handleCreateKey}
+							disabled={!newKeyName.trim()}
+							className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+						>
+							Create Key
+						</button>
+					</div>
+					<div className="flex items-center gap-4 text-xs text-muted-foreground">
+						<span className="font-medium text-foreground">Scopes:</span>
+						<label className="flex items-center gap-1.5 cursor-pointer">
+							<input
+								type="checkbox"
+								checked={newKeyScopeIngest}
+								onChange={(e) => setNewKeyScopeIngest(e.target.checked)}
+								className="rounded border-input"
+							/>
+							<span>ingest</span>
+							<span className="text-muted-foreground/60">(hook events)</span>
+						</label>
+						<label className="flex items-center gap-1.5 cursor-pointer">
+							<input
+								type="checkbox"
+								checked={newKeyScopeManage}
+								onChange={(e) => setNewKeyScopeManage(e.target.checked)}
+								className="rounded border-input"
+							/>
+							<span>manage</span>
+							<span className="text-muted-foreground/60">(supervisors, API keys)</span>
+						</label>
+					</div>
 				</div>
 
 				{/* Key list */}
@@ -460,6 +495,11 @@ export function SettingsPage() {
 										{key.lastUsedAt && (
 											<span className="text-xs text-muted-foreground">
 												Last used {new Date(key.lastUsedAt).toLocaleDateString()}
+											</span>
+										)}
+										{key.scopes && key.scopes.length > 0 && (
+											<span className="text-xs font-mono text-muted-foreground border border-border rounded px-1.5 py-0.5">
+												{key.scopes.join(", ")}
 											</span>
 										)}
 									</div>

--- a/src/web/pages/SetupPage.tsx
+++ b/src/web/pages/SetupPage.tsx
@@ -47,7 +47,9 @@ export function SetupPage() {
 		if (!newKeyName.trim()) return;
 		setCreatingKey(true);
 		try {
-			const res = await api.createApiKey(newKeyName.trim());
+			// Hook-setup keys are ingest-only: they go into agent hook config and
+			// must not carry management privileges. Use Settings to mint manage keys.
+			const res = await api.createApiKey(newKeyName.trim(), ["ingest"]);
 			setApiKey(res.key); // flow the raw key into the config blobs below
 			const list = await api.getApiKeys().catch(() => ({ keys }));
 			setKeys(list.keys ?? []);


### PR DESCRIPTION
Follow-ups surfaced during the SSO/node-killer work (PR #17). AGEN-10 (overlay rate-limit + /internal deny) was overlay-only and already applied to the cluster.

## AGEN-7 — embedding backfill circuit breaker
The backfill loop retried a failing adapter forever (fixed 1s backoff). With `AGENTPULSE_VECTOR_SEARCH=true` in prod, a down embedding endpoint hung the embed path indefinitely. Adds exponential backoff (1s→30s) + a circuit breaker (5 consecutive failures → structured warn + clean loop exit; re-fires on next trigger). No data loss, no spin.

## AGEN-8 — supervisor slot-takeover guard
A stolen *unscoped* enrollment token + a known supervisor UUID let an attacker re-register that supervisor (revoking the victim's credential, minting their own). Now rejected with 409 before the token is consumed; re-keying must go through `/admin/supervisors/:id/rotate`. New-host enrollment + scoped tokens unaffected.

## AGEN-9 — API key scoping (the big one)
Adds a `scopes` column to `api_keys` (default `["ingest"]`) + a `requireScope` middleware. An API-key caller may now only use the hook-ingest path; the **entire operator/dashboard API requires `manage`**. Human forwardauth/local sessions pass unconditionally — the dashboard UI is unaffected; only programmatic API-key callers are gated.

This closes a class of ingest-key privilege escalation a leaked hook key could previously reach: supervisor enroll/rotate/revoke, API-key minting, **AI HITL decision injection (agent prompt-injection / RCE)**, watcher `systemPrompt` overwrite, `templateClaudeMd` poisoning, Telegram-credential takeover, and the **WS live-session feed**.

- Scopes parsed/validated centrally; fail-closed to `["ingest"]`; unknown scopes rejected at mint; `*` honored only from the verified DB record.
- Dual-dialect `0002` migrations + legacy `runLegacySqliteInit` column/ALTER; existing keys backfill to `["ingest"]` (closes the hole).
- Hook-setup flows mint ingest-only keys; `DISABLE_AUTH` startup warning.

### ⚠️ Breaking for operators
Relay keys now need `["ingest","manage"]` (the relay proxies operator routes). Existing relay keys backfill to ingest-only and must be **re-minted with `manage`** (Settings → API Keys → check both scopes), or session-sync features 403 (hook forwarding still works). Documented in `scripts/setup-relay.sh`.

## Review
Plan (AGEN-9) reviewed by codex; both AGEN-8 and AGEN-9 (twice) gated by xander — the second xander pass is what expanded AGEN-9 from supervisor-only gating to the full operator API after finding the AI-control-plane holes. **931 tests, 0 failures**; typecheck + all 6 architecture guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)