### PR TITLE
test(auth): fix flaky trust-gate test (memoized secret leak across files)

### DIFF
--- a/src/server/auth/forwardauth-bridge.test.ts
+++ b/src/server/auth/forwardauth-bridge.test.ts
@@ -76,6 +76,10 @@ beforeAll(async () => {
 	process.env.FORWARDAUTH_TRUST_SECRET = TEST_SECRET;
 	process.env.FORWARDAUTH_PROVIDER = TEST_PROVIDER;
 	(config as Record<string, unknown>).disableAuth = false;
+	// config memoizes forwardauthTrustSecret; clear the memo so this file
+	// reads TEST_SECRET and so a stale memo from a prior file doesn't leak in.
+	// biome-ignore lint/performance/noDelete: clear Object.defineProperty-installed own property
+	delete (config as Record<string, unknown>)._forwardauthTrustSecret;
 });
 
 afterAll(() => {
@@ -90,6 +94,9 @@ afterAll(() => {
 	} else {
 		process.env.FORWARDAUTH_PROVIDER = originalProvider;
 	}
+	// Clear the memo so the restored env is what the next test file re-reads.
+	// biome-ignore lint/performance/noDelete: clear Object.defineProperty-installed own property
+	delete (config as Record<string, unknown>)._forwardauthTrustSecret;
 });
 
 // ─── Parse Set-Cookie helper ─────────────────────────────────────────────────

--- a/src/server/ws/ws-auth.test.ts
+++ b/src/server/ws/ws-auth.test.ts
@@ -18,6 +18,10 @@ const { SESSION_COOKIE_NAME, issueSession } = await import("../services/local-au
 const { guardWsUpgrade } = await import("./ws-auth.js");
 const { config } = await import("../config.js");
 
+// Save the original so we restore it (not hardcode) — otherwise disableAuth
+// leaks across test files and breaks order-dependent auth tests in CI.
+const originalDisableAuth = config.disableAuth;
+
 beforeAll(async () => {
 	await initializeDatabase();
 	// Ensure scope checks fire (don't skip due to disableAuth)
@@ -25,7 +29,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-	(config as Record<string, unknown>).disableAuth = true;
+	(config as Record<string, unknown>).disableAuth = originalDisableAuth;
 });
 
 function bearerHeaders(key: string): Headers {


### PR DESCRIPTION
CI (and the PR #17/#18 merge runs) failed on `trust gate — default Authentik header names > passes when verify header matches secret` — but only in CI's cross-file test order; it passed locally and in isolation.

Root cause: `config.forwardauthTrustSecret` is memoized (`_forwardauthTrustSecret`). `forwardauth-bridge.test.ts` set the env in `beforeAll` and memoized it, but never cleared the memo in teardown, so a stale secret leaked into `middleware.test.ts`'s trust-gate case. Fix clears the memo in `beforeAll` + `afterAll` (matching `app.integration.test.ts`). Verified the CI-order scenario (bridge → middleware → integration in one process) now passes; full suite 931/0; test-only, no production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)